### PR TITLE
chore:  respect catalog restriction in ListColumns

### DIFF
--- a/sqlconnect/db.go
+++ b/sqlconnect/db.go
@@ -8,12 +8,16 @@ import (
 	"time"
 )
 
-var ErrDropOldTablePostCopy = errors.New("move table: dropping old table after copying its contents to the new table")
+var (
+	ErrNotSupported         = errors.New("sqconnect: feature not supported")
+	ErrDropOldTablePostCopy = errors.New("sqlconnect move table: dropping old table after copying its contents to the new table")
+)
 
 type DB interface {
 	sqlDB
 	// SqlDB returns the underlying *sql.DB
 	SqlDB() *sql.DB
+	CatalogAdmin
 	SchemaAdmin
 	TableAdmin
 	JsonRowMapper
@@ -41,6 +45,12 @@ type sqlDB interface {
 	SetMaxIdleConns(n int)
 	SetMaxOpenConns(n int)
 	Stats() sql.DBStats
+}
+
+type CatalogAdmin interface {
+	// CurrentCatalog returns the current catalog.
+	// If this operation is not supported by the warehouse [ErrNotSupported] will be returned.
+	CurrentCatalog(ctx context.Context) (string, error)
 }
 
 type SchemaAdmin interface {

--- a/sqlconnect/internal/base/catalog_admin.go
+++ b/sqlconnect/internal/base/catalog_admin.go
@@ -1,0 +1,15 @@
+package base
+
+import (
+	"context"
+	"fmt"
+)
+
+// CurrentCatalog returns the current catalog
+func (db *DB) CurrentCatalog(ctx context.Context) (string, error) {
+	var catalog string
+	if err := db.QueryRowContext(ctx, db.sqlCommands.CurrentCatalog()).Scan(&catalog); err != nil {
+		return "", fmt.Errorf("getting current catalog: %w", err)
+	}
+	return catalog, nil
+}

--- a/sqlconnect/internal/base/tableadmin.go
+++ b/sqlconnect/internal/base/tableadmin.go
@@ -133,7 +133,7 @@ func (db *DB) TableExists(ctx context.Context, relation sqlconnect.RelationRef) 
 // ListColumns returns a list of columns for the given table
 func (db *DB) ListColumns(ctx context.Context, relation sqlconnect.RelationRef) ([]sqlconnect.ColumnRef, error) {
 	var res []sqlconnect.ColumnRef
-	stmt, nameCol, typeCol := db.sqlCommands.ListColumns(UnquotedIdentifier(relation.Schema), UnquotedIdentifier(relation.Name))
+	stmt, nameCol, typeCol := db.sqlCommands.ListColumns(UnquotedIdentifier(relation.Catalog), UnquotedIdentifier(relation.Schema), UnquotedIdentifier(relation.Name))
 	columns, err := db.QueryContext(ctx, stmt)
 	if err != nil {
 		return nil, fmt.Errorf("querying list columns for %s: %w", relation.String(), err)

--- a/sqlconnect/internal/bigquery/catalogadmin.go
+++ b/sqlconnect/internal/bigquery/catalogadmin.go
@@ -1,0 +1,18 @@
+package bigquery
+
+import (
+	"context"
+
+	"cloud.google.com/go/bigquery"
+)
+
+func (db *DB) CurrentCatalog(ctx context.Context) (string, error) {
+	var catalog string
+	if err := db.WithBigqueryClient(ctx, func(c *bigquery.Client) error {
+		catalog = c.Project()
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	return catalog, nil
+}

--- a/sqlconnect/internal/bigquery/db.go
+++ b/sqlconnect/internal/bigquery/db.go
@@ -52,8 +52,12 @@ func NewDB(configJSON json.RawMessage) (*DB, error) {
 				cmds.TableExists = func(schema, table base.UnquotedIdentifier) string {
 					return fmt.Sprintf("SELECT table_name FROM `%[1]s`.INFORMATION_SCHEMA.TABLES WHERE table_name = '%[2]s'", schema, table)
 				}
-				cmds.ListColumns = func(schema, table base.UnquotedIdentifier) (string, string, string) {
-					return fmt.Sprintf("SELECT column_name, data_type FROM `%[1]s`.INFORMATION_SCHEMA.COLUMNS WHERE table_name = '%[2]s'", schema, table), "column_name", "data_type"
+				cmds.ListColumns = func(catalog, schema, table base.UnquotedIdentifier) (string, string, string) {
+					stmt := fmt.Sprintf("SELECT column_name, data_type FROM `%[1]s`.INFORMATION_SCHEMA.COLUMNS WHERE table_name = '%[2]s'", schema, table)
+					if catalog != "" {
+						stmt += fmt.Sprintf(" AND table_catalog = '%[1]s'", catalog)
+					}
+					return stmt, "column_name", "data_type"
 				}
 
 				return cmds

--- a/sqlconnect/internal/databricks/config.go
+++ b/sqlconnect/internal/databricks/config.go
@@ -25,8 +25,5 @@ func (c *Config) Parse(configJson json.RawMessage) error {
 	if err != nil {
 		return err
 	}
-	if c.Catalog == "" {
-		c.Catalog = "hive_metastore" // default catalog
-	}
 	return nil
 }

--- a/sqlconnect/internal/databricks/db.go
+++ b/sqlconnect/internal/databricks/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	databricks "github.com/databricks/databricks-sql-go"
 	"github.com/samber/lo"
@@ -44,6 +45,11 @@ func NewDB(configJson json.RawMessage) (*DB, error) {
 	db := sql.OpenDB(connector)
 	db.SetConnMaxIdleTime(config.MaxConnIdleTime)
 
+	if _, err = db.Exec("SELECT * FROM INFORMATION_SCHEMA.COLUMNS LIMIT 1"); err != nil && !strings.Contains(err.Error(), "TABLE_OR_VIEW_NOT_FOUND") {
+		return nil, fmt.Errorf("checking if unity catalog is available: %w", err)
+	}
+	informationSchema := err == nil
+
 	return &DB{
 		DB: base.NewDB(
 			db,
@@ -51,6 +57,9 @@ func NewDB(configJson json.RawMessage) (*DB, error) {
 			base.WithColumnTypeMapper(getColumnTypeMapper(config)),
 			base.WithJsonRowMapper(getJonRowMapper(config)),
 			base.WithSQLCommandsOverride(func(cmds base.SQLCommands) base.SQLCommands {
+				cmds.CurrentCatalog = func() string {
+					return "SELECT current_catalog()"
+				}
 				cmds.ListSchemas = func() (string, string) { return "SHOW SCHEMAS", "schema_name" }
 				cmds.SchemaExists = func(schema base.UnquotedIdentifier) string { return fmt.Sprintf(`SHOW SCHEMAS LIKE '%s'`, schema) }
 
@@ -70,12 +79,30 @@ func NewDB(configJson json.RawMessage) (*DB, error) {
 				cmds.TableExists = func(schema, table base.UnquotedIdentifier) string {
 					return fmt.Sprintf("SHOW TABLES IN `%[1]s` LIKE '%[2]s'", schema, table)
 				}
-				cmds.ListColumns = func(schema, table base.UnquotedIdentifier) (string, string, string) {
-					return fmt.Sprintf("DESCRIBE TABLE `%[1]s`.`%[2]s`", schema, table), "col_name", "data_type"
+				cmds.ListColumns = func(catalog, schema, table base.UnquotedIdentifier) (string, string, string) {
+					if catalog == "" || !informationSchema {
+						return fmt.Sprintf("DESCRIBE TABLE `%[1]s`.`%[2]s`", schema, table), "col_name", "data_type"
+					}
+					stmt := fmt.Sprintf(`SELECT 
+											column_name, 
+											data_type 
+										FROM information_schema.columns 
+										WHERE table_schema = '%[1]s' 
+										AND table_name = '%[2]s'
+										AND table_catalog='%[3]s' 
+										ORDER BY ORDINAL_POSITION ASC`,
+						schema,
+						table,
+						catalog)
+					return stmt, "column_name", "data_type"
+				}
+				cmds.RenameTable = func(schema, oldName, newName base.QuotedIdentifier) string {
+					return fmt.Sprintf("ALTER TABLE %[1]s.%[2]s RENAME TO %[1]s.%[3]s", schema, oldName, newName)
 				}
 				return cmds
 			}),
 		),
+		informationSchema: informationSchema,
 	}, nil
 }
 
@@ -87,6 +114,7 @@ func init() {
 
 type DB struct {
 	*base.DB
+	informationSchema bool
 }
 
 func getColumnTypeMapper(config Config) func(base.ColumnType) string {

--- a/sqlconnect/internal/databricks/integration_test.go
+++ b/sqlconnect/internal/databricks/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/sjson"
 
+	"github.com/rudderlabs/sqlconnect-go/sqlconnect"
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/databricks"
 	integrationtest "github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/integration_test"
 )
@@ -26,5 +27,26 @@ func TestDatabricksDB(t *testing.T) {
 	configJSON, err = sjson.Set(configJSON, "maxRetryWaitTime", 30*time.Second)
 	require.NoError(t, err, "failed to set maxRetryWaitTime")
 
-	integrationtest.TestDatabaseScenarios(t, databricks.DatabaseType, []byte(configJSON), strings.ToLower, integrationtest.Options{LegacySupport: true})
+	t.Run("with information schema", func(t *testing.T) {
+		configJSON, err := sjson.Set(configJSON, "catalog", "sqlconnect")
+		require.NoError(t, err, "failed to set catalog")
+		db, err := sqlconnect.NewDB(databricks.DatabaseType, []byte(configJSON))
+		require.NoError(t, err, "failed to create db")
+		_, err = db.Exec("SELECT * FROM INFORMATION_SCHEMA.COLUMNS LIMIT 1")
+		require.NoError(t, err, "information schema should be available")
+
+		integrationtest.TestDatabaseScenarios(t, databricks.DatabaseType, []byte(configJSON), strings.ToLower, integrationtest.Options{LegacySupport: true})
+	})
+
+	t.Run("without information schema", func(t *testing.T) {
+		configJSON, err := sjson.Set(configJSON, "catalog", "hive_metastore")
+		require.NoError(t, err, "failed to set catalog")
+		db, err := sqlconnect.NewDB(databricks.DatabaseType, []byte(configJSON))
+		require.NoError(t, err, "failed to create db")
+		_, err = db.Exec("SELECT * FROM INFORMATION_SCHEMA.COLUMNS LIMIT 1")
+		require.Error(t, err, "information schema should not be available")
+		require.ErrorContains(t, err, "TABLE_OR_VIEW_NOT_FOUND", "information schema should not be available")
+
+		integrationtest.TestDatabaseScenarios(t, databricks.DatabaseType, []byte(configJSON), strings.ToLower, integrationtest.Options{LegacySupport: true})
+	})
 }

--- a/sqlconnect/internal/databricks/tableadmin.go
+++ b/sqlconnect/internal/databricks/tableadmin.go
@@ -2,10 +2,25 @@ package databricks
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect"
 )
+
+// ListColumns returns a list of columns for the given table
+func (db *DB) ListColumns(ctx context.Context, relation sqlconnect.RelationRef) ([]sqlconnect.ColumnRef, error) {
+	if !db.informationSchema && relation.Catalog != "" {
+		currentCatalog, err := db.CurrentCatalog(ctx) // make sure the catalog matches the current catalog
+		if err != nil {
+			return nil, fmt.Errorf("getting current catalog: %w", err)
+		}
+		if relation.Catalog != currentCatalog {
+			return nil, fmt.Errorf("catalog %s not found", relation.Catalog)
+		}
+	}
+	return db.DB.ListColumns(ctx, relation)
+}
 
 // RenameTable in databricks falls back to MoveTable if rename is not supported
 func (db *DB) RenameTable(ctx context.Context, oldRef, newRef sqlconnect.RelationRef) error {

--- a/sqlconnect/internal/mysql/catalogadmin.go
+++ b/sqlconnect/internal/mysql/catalogadmin.go
@@ -1,0 +1,12 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/rudderlabs/sqlconnect-go/sqlconnect"
+)
+
+// CurrentCatalog returns an error because it is not supported by MySQL
+func (db *DB) CurrentCatalog(ctx context.Context) (string, error) {
+	return "", sqlconnect.ErrNotSupported
+}

--- a/sqlconnect/internal/mysql/db.go
+++ b/sqlconnect/internal/mysql/db.go
@@ -38,6 +38,9 @@ func NewDB(configJSON json.RawMessage) (*DB, error) {
 			base.WithColumnTypeMapper(getColumnTypeMapper(config)),
 			base.WithJsonRowMapper(getJonRowMapper(config)),
 			base.WithSQLCommandsOverride(func(cmds base.SQLCommands) base.SQLCommands {
+				cmds.CurrentCatalog = func() string {
+					return "SELECT DATABASE()"
+				}
 				cmds.DropSchema = func(schema base.QuotedIdentifier) string { // mysql does not support CASCADE
 					return fmt.Sprintf("DROP SCHEMA %[1]s", schema)
 				}

--- a/sqlconnect/internal/redshift/db.go
+++ b/sqlconnect/internal/redshift/db.go
@@ -35,6 +35,9 @@ func NewDB(credentialsJSON json.RawMessage) (*DB, error) {
 			base.WithColumnTypeMappings(getColumnTypeMappings(config)),
 			base.WithJsonRowMapper(getJonRowMapper(config)),
 			base.WithSQLCommandsOverride(func(cmds base.SQLCommands) base.SQLCommands {
+				cmds.CurrentCatalog = func() string {
+					return "SELECT current_database()"
+				}
 				cmds.ListSchemas = func() (string, string) {
 					return "SELECT schema_name FROM svv_redshift_schemas", "schema_name"
 				}


### PR DESCRIPTION
# Description
If a catalog is passed as an argument in `ListColumns`, it should be included as a condition it in the sql statement.

**_Bonus:_** introducing `CurrentCatalog` method to get the current catalog.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
