### PR TITLE
chore(databricks): use full_data_type instead of data_type when listing columns

### DIFF
--- a/sqlconnect/internal/databricks/db.go
+++ b/sqlconnect/internal/databricks/db.go
@@ -99,7 +99,7 @@ func NewDB(configJson json.RawMessage) (*DB, error) {
 					}
 					stmt := fmt.Sprintf(`SELECT 
 											column_name, 
-											data_type 
+											full_data_type 
 										FROM information_schema.columns 
 										WHERE table_schema = '%[1]s' 
 										AND table_name = '%[2]s'
@@ -108,7 +108,7 @@ func NewDB(configJson json.RawMessage) (*DB, error) {
 						schema,
 						table,
 						catalog)
-					return stmt, "column_name", "data_type"
+					return stmt, "column_name", "full_data_type"
 				}
 				cmds.RenameTable = func(schema, oldName, newName base.QuotedIdentifier) string {
 					return fmt.Sprintf("ALTER TABLE %[1]s.%[2]s RENAME TO %[1]s.%[3]s", schema, oldName, newName)


### PR DESCRIPTION
# Description

Using `full_data_type `column in databricks so that `rawType` contains the full data type

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
