### PR TITLE
fix: bigquery driver not honouring context while querying

### DIFF
--- a/sqlconnect/internal/bigquery/driver/statement.go
+++ b/sqlconnect/internal/bigquery/driver/statement.go
@@ -55,7 +55,7 @@ func (statement *bigQueryStatement) QueryContext(ctx context.Context, args []dri
 		return nil, err
 	}
 
-	rowIterator, err := query.Read(context.Background())
+	rowIterator, err := query.Read(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

Using provided context instead of `context.Background` during `QueryContext`

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
