### PR TITLE
chore(bigquery): add support for retrying jobRateLimitExceeded errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.25.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.11
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.25.4
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/databricks/databricks-sql-go v1.5.3
 	github.com/dlclark/regexp2 v1.11.0
 	github.com/gliderlabs/ssh v0.3.7
@@ -27,6 +28,7 @@ require (
 	github.com/tidwall/sjson v1.2.5
 	github.com/trinodb/trino-go-client v0.313.0
 	golang.org/x/crypto v0.21.0
+	golang.org/x/sync v0.6.0
 	google.golang.org/api v0.172.0
 )
 
@@ -64,7 +66,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.23.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.5.0 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
@@ -136,7 +137,6 @@ require (
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect
-	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/sqlconnect/internal/bigquery/db.go
+++ b/sqlconnect/internal/bigquery/db.go
@@ -28,7 +28,13 @@ func NewDB(configJSON json.RawMessage) (*DB, error) {
 		return nil, err
 	}
 
-	db := sql.OpenDB(driver.NewConnector(config.ProjectID, option.WithCredentialsJSON([]byte(config.CredentialsJSON))))
+	db := sql.OpenDB(driver.NewConnector(
+		config.ProjectID,
+		driver.Config{
+			JobRateLimitExceededRetryEnabled: true,
+		},
+		option.WithCredentialsJSON([]byte(config.CredentialsJSON))),
+	)
 
 	return &DB{
 		DB: base.NewDB(

--- a/sqlconnect/internal/bigquery/driver/connector.go
+++ b/sqlconnect/internal/bigquery/driver/connector.go
@@ -8,15 +8,21 @@ import (
 	"google.golang.org/api/option"
 )
 
-func NewConnector(projectID string, opts ...option.ClientOption) driver.Connector {
+type Config struct {
+	JobRateLimitExceededRetryEnabled bool // Enable jobRateLimitExceeded retries: default false
+}
+
+func NewConnector(projectID string, config Config, opts ...option.ClientOption) driver.Connector {
 	return &bigQueryConnector{
 		projectID: projectID,
+		config:    config,
 		opts:      opts,
 	}
 }
 
 type bigQueryConnector struct {
 	projectID string
+	config    Config
 	opts      []option.ClientOption
 }
 
@@ -27,6 +33,7 @@ func (c *bigQueryConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	}
 
 	return &bigQueryConnection{
+		config: c.config,
 		ctx:    ctx,
 		client: client,
 	}, nil

--- a/sqlconnect/internal/bigquery/driver/driver_test.go
+++ b/sqlconnect/internal/bigquery/driver/driver_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/option"
 
 	"github.com/rudderlabs/rudder-go-kit/testhelper/rand"
@@ -33,7 +34,7 @@ func TestBigqueryDriver(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(configJSON), &c))
 
 	t.Run("OpenDB", func(t *testing.T) {
-		db := sql.OpenDB(driver.NewConnector(c.ProjectID, option.WithCredentialsJSON([]byte(c.CredentialsJSON))))
+		db := sql.OpenDB(driver.NewConnector(c.ProjectID, driver.Config{}, option.WithCredentialsJSON([]byte(c.CredentialsJSON))))
 		t.Cleanup(func() {
 			require.NoError(t, db.Close(), "it should be able to close the database connection")
 		})
@@ -221,6 +222,51 @@ func TestBigqueryDriver(t *testing.T) {
 			require.False(t, rows.Next(), "it shouldn't have next row")
 
 			require.NoError(t, rows.Err())
+		})
+	})
+
+	// TODO: this test should start failing once this fix is released:
+	// https://github.com/googleapis/google-cloud-go/pull/9726
+	t.Run("jobRateLimitExceeded", func(t *testing.T) {
+		t.Run("selecting from information schema from multiple go-routines should lead to a jobRateLimitExceeded error", func(t *testing.T) {
+			db := sql.OpenDB(driver.NewConnector(c.ProjectID, driver.Config{}, option.WithCredentialsJSON([]byte(c.CredentialsJSON))))
+			t.Cleanup(func() {
+				require.NoError(t, db.Close(), "it should be able to close the database connection")
+			})
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			g, ctx := errgroup.WithContext(ctx)
+			g.SetLimit(10)
+			for i := 0; i < 200; i++ {
+				g.Go(func() error {
+					_, err := db.ExecContext(ctx, "SELECT * FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'invalid'")
+					return err
+				})
+			}
+			err := g.Wait()
+			require.Error(t, err, "it should return an error")
+			require.Contains(t, err.Error(), "jobRateLimitExceeded", "it should return a jobRateLimitExceeded error")
+		})
+
+		t.Run("selecting from information schema from multiple go-routines and having rate limit retries enabled, shoudln't lead to a jobRateLimitExceeded error", func(t *testing.T) {
+			db := sql.OpenDB(driver.NewConnector(c.ProjectID, driver.Config{JobRateLimitExceededRetryEnabled: true}, option.WithCredentialsJSON([]byte(c.CredentialsJSON))))
+			t.Cleanup(func() {
+				require.NoError(t, db.Close(), "it should be able to close the database connection")
+			})
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			g, ctx := errgroup.WithContext(ctx)
+			g.SetLimit(10)
+			for i := 0; i < 50; i++ {
+				g.Go(func() error {
+					_, err := db.ExecContext(ctx, "SELECT * FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = 'invalid'")
+					return err
+				})
+			}
+			err := g.Wait()
+			require.NoError(t, err, "it shouldn't return an error")
 		})
 	})
 }

--- a/sqlconnect/internal/bigquery/driver/statement.go
+++ b/sqlconnect/internal/bigquery/driver/statement.go
@@ -41,7 +41,7 @@ func (statement *bigQueryStatement) ExecContext(ctx context.Context, args []driv
 		return nil, err
 	}
 
-	rowIterator, err := query.Read(ctx)
+	rowIterator, err := statement.connection.readWithBackoff(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (statement *bigQueryStatement) QueryContext(ctx context.Context, args []dri
 		return nil, err
 	}
 
-	rowIterator, err := query.Read(ctx)
+	rowIterator, err := statement.connection.readWithBackoff(ctx, query)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

This change is needed until bigquery client starts auto retrying `jobRateLimitExceeded` errors on its own ([link](https://github.com/googleapis/google-cloud-go/pull/9726/files))

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
