### PR TITLE
fix(snowflake): audiences stopped supporting views

### DIFF
--- a/sqlconnect/internal/bigquery/integration_test.go
+++ b/sqlconnect/internal/bigquery/integration_test.go
@@ -18,5 +18,13 @@ func TestBigqueryDB(t *testing.T) {
 		}
 		t.Skip("skipping bigquery integration test due to lack of a test environment")
 	}
-	integrationtest.TestDatabaseScenarios(t, bigquery.DatabaseType, []byte(configJSON), strings.ToLower, integrationtest.Options{LegacySupport: true})
+	integrationtest.TestDatabaseScenarios(
+		t,
+		bigquery.DatabaseType,
+		[]byte(configJSON),
+		strings.ToLower,
+		integrationtest.Options{
+			LegacySupport: true,
+		},
+	)
 }

--- a/sqlconnect/internal/databricks/integration_test.go
+++ b/sqlconnect/internal/databricks/integration_test.go
@@ -37,7 +37,15 @@ func TestDatabricksDB(t *testing.T) {
 		_, err = db.Exec("SELECT * FROM INFORMATION_SCHEMA.COLUMNS LIMIT 1")
 		require.NoError(t, err, "information schema should be available")
 
-		integrationtest.TestDatabaseScenarios(t, databricks.DatabaseType, []byte(configJSON), strings.ToLower, integrationtest.Options{LegacySupport: true})
+		integrationtest.TestDatabaseScenarios(
+			t,
+			databricks.DatabaseType,
+			[]byte(configJSON),
+			strings.ToLower,
+			integrationtest.Options{
+				LegacySupport: true,
+			},
+		)
 	})
 
 	t.Run("without information schema", func(t *testing.T) {
@@ -49,7 +57,15 @@ func TestDatabricksDB(t *testing.T) {
 		require.Error(t, err, "information schema should not be available")
 		require.ErrorContains(t, err, "TABLE_OR_VIEW_NOT_FOUND", "information schema should not be available")
 
-		integrationtest.TestDatabaseScenarios(t, databricks.DatabaseType, []byte(configJSON), strings.ToLower, integrationtest.Options{LegacySupport: true})
+		integrationtest.TestDatabaseScenarios(
+			t,
+			databricks.DatabaseType,
+			[]byte(configJSON),
+			strings.ToLower,
+			integrationtest.Options{
+				LegacySupport: true,
+			},
+		)
 
 		integrationtest.TestSshTunnelScenarios(t, databricks.DatabaseType, []byte(configJSON))
 	})

--- a/sqlconnect/internal/mysql/integration_test.go
+++ b/sqlconnect/internal/mysql/integration_test.go
@@ -34,7 +34,15 @@ func TestMysqlDB(t *testing.T) {
 	configJSON, err := json.Marshal(config)
 	require.NoError(t, err, "it should be able to marshal config to json")
 
-	integrationtest.TestDatabaseScenarios(t, mysql.DatabaseType, configJSON, strings.ToLower, integrationtest.Options{LegacySupport: true})
+	integrationtest.TestDatabaseScenarios(
+		t,
+		mysql.DatabaseType,
+		configJSON,
+		strings.ToLower,
+		integrationtest.Options{
+			LegacySupport: true,
+		},
+	)
 
 	integrationtest.TestSshTunnelScenarios(t, mysql.DatabaseType, configJSON)
 }

--- a/sqlconnect/internal/postgres/integration_test.go
+++ b/sqlconnect/internal/postgres/integration_test.go
@@ -34,7 +34,15 @@ func TestPostgresDB(t *testing.T) {
 	configJSON, err := json.Marshal(config)
 	require.NoError(t, err, "it should be able to marshal config to json")
 
-	integrationtest.TestDatabaseScenarios(t, postgres.DatabaseType, configJSON, strings.ToLower, integrationtest.Options{LegacySupport: true})
+	integrationtest.TestDatabaseScenarios(
+		t,
+		postgres.DatabaseType,
+		configJSON,
+		strings.ToLower,
+		integrationtest.Options{
+			LegacySupport: true,
+		},
+	)
 
 	integrationtest.TestSshTunnelScenarios(t, postgres.DatabaseType, configJSON)
 }

--- a/sqlconnect/internal/redshift/integration_test.go
+++ b/sqlconnect/internal/redshift/integration_test.go
@@ -19,7 +19,15 @@ func TestRedshiftDB(t *testing.T) {
 			t.Skip("skipping redshift postgres driver integration test due to lack of a test environment")
 		}
 
-		integrationtest.TestDatabaseScenarios(t, redshift.DatabaseType, []byte(configJSON), strings.ToLower, integrationtest.Options{LegacySupport: true})
+		integrationtest.TestDatabaseScenarios(
+			t,
+			redshift.DatabaseType,
+			[]byte(configJSON),
+			strings.ToLower,
+			integrationtest.Options{
+				LegacySupport: true,
+			},
+		)
 
 		integrationtest.TestSshTunnelScenarios(t, redshift.DatabaseType, []byte(configJSON))
 	})
@@ -32,6 +40,14 @@ func TestRedshiftDB(t *testing.T) {
 			}
 			t.Skip("skipping redshift data driver integration test due to lack of a test environment")
 		}
-		integrationtest.TestDatabaseScenarios(t, redshift.DatabaseType, []byte(configJSON), strings.ToLower, integrationtest.Options{LegacySupport: true})
+		integrationtest.TestDatabaseScenarios(
+			t,
+			redshift.DatabaseType,
+			[]byte(configJSON),
+			strings.ToLower,
+			integrationtest.Options{
+				LegacySupport: true,
+			},
+		)
 	})
 }

--- a/sqlconnect/internal/snowflake/db.go
+++ b/sqlconnect/internal/snowflake/db.go
@@ -52,6 +52,7 @@ func NewDB(configJSON json.RawMessage) (*DB, error) {
 				cmds.ListTables = func(schema base.UnquotedIdentifier) []lo.Tuple2[string, string] {
 					return []lo.Tuple2[string, string]{
 						{A: fmt.Sprintf(`SHOW TERSE TABLES IN SCHEMA "%[1]s"`, schema), B: "name"},
+						{A: fmt.Sprintf(`SHOW TERSE VIEWS IN SCHEMA "%[1]s"`, schema), B: "name"},
 					}
 				}
 				cmds.ListTablesWithPrefix = func(schema base.UnquotedIdentifier, prefix string) []lo.Tuple2[string, string] {

--- a/sqlconnect/internal/snowflake/integration_test.go
+++ b/sqlconnect/internal/snowflake/integration_test.go
@@ -18,5 +18,14 @@ func TestSnowflakeDB(t *testing.T) {
 		t.Skip("skipping snowflake integration test due to lack of a test environment")
 	}
 
-	integrationtest.TestDatabaseScenarios(t, snowflake.DatabaseType, []byte(configJSON), strings.ToUpper, integrationtest.Options{LegacySupport: true})
+	integrationtest.TestDatabaseScenarios(
+		t,
+		snowflake.DatabaseType,
+		[]byte(configJSON),
+		strings.ToUpper,
+		integrationtest.Options{
+			LegacySupport:             true,
+			IncludesViewsInListTables: true,
+		},
+	)
 }

--- a/sqlconnect/internal/trino/integration_test.go
+++ b/sqlconnect/internal/trino/integration_test.go
@@ -19,7 +19,13 @@ func TestTrinoDB(t *testing.T) {
 		t.Skip("skipping trino integration test due to lack of a test environment")
 	}
 
-	integrationtest.TestDatabaseScenarios(t, trino.DatabaseType, []byte(configJSON), strings.ToLower, integrationtest.Options{})
+	integrationtest.TestDatabaseScenarios(
+		t,
+		trino.DatabaseType,
+		[]byte(configJSON),
+		strings.ToLower,
+		integrationtest.Options{},
+	)
 
 	integrationtest.TestSshTunnelScenarios(t, trino.DatabaseType, []byte(configJSON))
 }


### PR DESCRIPTION
# Description

In case of `snowflake`, the old library's `ListTables` method was listing views along with tables ([link](https://github.com/rudderlabs/rudder-sources/blob/v1.46.2/integrations/sqlsource/client/snowflake/snowflake.go#L382)). 

Even though we did add support in the new library to execute more than 1 queries during `ListTables`, we forgot to include the second query for `snowflake`, one for including the views, i.e. `show terse views in schema`.

Adding the missing views' query in `snowflake`, along with a relevant test scenario.


## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
