### PR TITLE
chore(redshift-data): add support for RetryMaxAttempts with default value set to 20

### DIFF
--- a/sqlconnect/internal/redshift/config.go
+++ b/sqlconnect/internal/redshift/config.go
@@ -30,9 +30,10 @@ type Config struct {
 	SecretAccessKey string `json:"secretAccessKey"`
 	SessionToken    string `json:"sessionToken"`
 
-	Timeout    time.Duration `json:"timeout"`    // default: no timeout
-	MinPolling time.Duration `json:"minPolling"` // default: 10ms
-	MaxPolling time.Duration `json:"maxPolling"` // default: 5s
+	Timeout          time.Duration `json:"timeout"`          // default: no timeout
+	MinPolling       time.Duration `json:"minPolling"`       // default: 10ms
+	MaxPolling       time.Duration `json:"maxPolling"`       // default: 5s
+	RetryMaxAttempts int           `json:"retryMaxAttempts"` // default: 20
 
 	UseLegacyMappings bool `json:"useLegacyMappings"`
 }

--- a/sqlconnect/internal/redshift/db.go
+++ b/sqlconnect/internal/redshift/db.go
@@ -104,6 +104,7 @@ func newRedshiftDataDB(credentialsJSON json.RawMessage) (*sql.DB, error) {
 		Timeout:           config.Timeout,
 		MinPolling:        config.MinPolling,
 		MaxPolling:        config.MaxPolling,
+		RetryMaxAttempts:  config.RetryMaxAttempts,
 	}
 	connector := redshiftdriver.NewRedshiftConnector(cfg)
 

--- a/sqlconnect/internal/redshift/driver/dsn_test.go
+++ b/sqlconnect/internal/redshift/driver/dsn_test.go
@@ -42,8 +42,9 @@ func TestRedshiftDataConfig__String(t *testing.T) {
 				Database:          "dev",
 				MinPolling:        5 * time.Millisecond,
 				MaxPolling:        2 * time.Second,
+				RetryMaxAttempts:  3,
 			},
-			expected: "admin@cluster(default)/dev?maxPolling=2s&minPolling=5ms",
+			expected: "admin@cluster(default)/dev?maxPolling=2s&minPolling=5ms&retryMaxAttempts=3",
 		},
 		{
 			dsn: &RedshiftConfig{


### PR DESCRIPTION
# Description

Using 20 retries by default in redshift-data driver, since 3 is too low. Allowing to override the default behaviour through a config option.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
