### PR TITLE
chore(databricks): add configuration option for setting the default schema

### DIFF
--- a/sqlconnect/internal/databricks/config.go
+++ b/sqlconnect/internal/databricks/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Path    string `json:"path"`
 	Token   string `json:"token"`
 	Catalog string `json:"catalog"`
+	Schema  string `json:"schema"`
 
 	TunnelInfo *sshtunnel.Config `json:"tunnel_info,omitempty"`
 

--- a/sqlconnect/internal/databricks/db.go
+++ b/sqlconnect/internal/databricks/db.go
@@ -31,7 +31,7 @@ func NewDB(configJson json.RawMessage) (*DB, error) {
 		databricks.WithServerHostname(config.Host),
 		databricks.WithPort(config.Port),
 		databricks.WithHTTPPath(config.Path),
-		databricks.WithInitialNamespace(config.Catalog, ""),
+		databricks.WithInitialNamespace(config.Catalog, config.Schema),
 		databricks.WithRetries(
 			config.RetryAttempts,
 			config.MinRetryWaitTime,


### PR DESCRIPTION
# Description

Add configuration option in databricks for setting the default schema 

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
