### PR TITLE
chore(deps): bump rudder-go-kit to v0.29.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/rudderlabs/rudder-go-kit v0.27.0
+	github.com/rudderlabs/rudder-go-kit v0.29.0
 	github.com/rudderlabs/sql-tunnels v0.1.6
 	github.com/samber/lo v1.39.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
 github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
-github.com/rudderlabs/rudder-go-kit v0.27.0 h1:GWJwhOcohTrWPgMlmhif/jCkMWylOcjesYNVFrMLUo4=
-github.com/rudderlabs/rudder-go-kit v0.27.0/go.mod h1:l+kq8EE3r08GcoBw1JO/AJ8O+tQqJnuwLNirWSnVIrk=
+github.com/rudderlabs/rudder-go-kit v0.29.0 h1:zz70OGuT9lCVSoUkLuBKNfGaR9Sz+QZwdu+T4F8ItdY=
+github.com/rudderlabs/rudder-go-kit v0.29.0/go.mod h1:dSJQHi1yR7wWps5BVQFpL56eRXk1bwCRDbuFDeplYSM=
 github.com/rudderlabs/sql-tunnels v0.1.6 h1:v2KA2cq8ZV5LXRJQpqigq1Q4V64oDL+XlfckW/0K2/4=
 github.com/rudderlabs/sql-tunnels v0.1.6/go.mod h1:Jew/XwojzFTK4KTDj/wvChI7iZCgAKYyKjFK1nnHlNM=
 github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=


### PR DESCRIPTION
# Description

Bump rudder-go-kit to v0.29.0

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
