### PR TITLE
chore: use go 1.22 with toolchain

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.0'
+          go-version: 1.22
           check-latest: true
       - name: Download coverage reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           check-latest: true
           cache: true
-          go-version: '1.22.0'
+          go-version: 1.22
       - run: go version
 
       - run: go mod tidy
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.0'
+          go-version: 1.22
           check-latest: true
           cache: true
       - name: golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rudderlabs/sqlconnect-go
 
-go 1.22.0
+go 1.22
+
+toolchain go1.22.2
 
 require (
 	cloud.google.com/go v0.112.2


### PR DESCRIPTION
# Description

Using the standard go with toolchain in go.mod

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
