### PR TITLE
feat: add array data type support for legacy mappings

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, they will 
 # be requested for review when someone opens a pull request.
-*       @atzoum
+*       @atzoum @AchuthaSourabhC @RanjeetMishra
 
 # Order is important; the last matching pattern takes the most
 # precedence.

--- a/sqlconnect/internal/integration_test/db_integration_test_scenario.go
+++ b/sqlconnect/internal/integration_test/db_integration_test_scenario.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -517,6 +518,9 @@ func TestDatabaseScenarios(t *testing.T, warehouse string, configJSON json.RawMe
 					require.Truef(t, ok, "column of type datetime should be parsed as a datetime %q: %v", col.Name, actualRow[col.Name])
 					_, err := time.Parse(time.RFC3339, datetime)
 					require.NoErrorf(t, err, "column of type datetime should be a RFC3339 string %q: %v", col.Name, actualRow[col.Name])
+				case "array":
+					require.Truef(t, reflect.TypeOf(actualRow[col.Name]).Kind() == reflect.Slice, "column of type array should be a slice %q: %v", col.Name, actualRow[col.Name])
+
 				case "json":
 					// this can be anything
 				default:

--- a/sqlconnect/internal/snowflake/legacy_mappings.go
+++ b/sqlconnect/internal/snowflake/legacy_mappings.go
@@ -44,6 +44,7 @@ func legacyColumnTypeMapper(columnType base.ColumnType) string {
 		"TIMESTAMP_LTZ":    "datetime",
 		"TIMESTAMP_TZ":     "datetime",
 		"VARIANT":          "json",
+		"ARRAY":            "array",
 	}
 	databaseTypeName := strings.ToUpper(re.ReplaceAllString(columnType.DatabaseTypeName(), ""))
 	if mappedType, ok := columnTypeMappings[strings.ToUpper(databaseTypeName)]; ok {

--- a/sqlconnect/internal/snowflake/mappings.go
+++ b/sqlconnect/internal/snowflake/mappings.go
@@ -47,7 +47,7 @@ var columnTypeMappings = map[string]string{
 	"TIMESTAMP_TZ":     "datetime",
 	"VARIANT":          "json",
 	"OBJECT":           "json",
-	"ARRAY":            "json",
+	"ARRAY":            "array",
 }
 
 var (

--- a/sqlconnect/internal/snowflake/testdata/column-mapping-test-columns.json
+++ b/sqlconnect/internal/snowflake/testdata/column-mapping-test-columns.json
@@ -31,5 +31,5 @@
     "_TIMESTAMPTZ": "datetime",
     "_VARIANT": "json",
     "_OBJECT": "json",
-    "_ARRAY": "json"
+    "_ARRAY": "array"
 }

--- a/sqlconnect/internal/snowflake/testdata/legacy-column-mapping-test-columns-sql.json
+++ b/sqlconnect/internal/snowflake/testdata/legacy-column-mapping-test-columns-sql.json
@@ -31,5 +31,5 @@
     "_TIMESTAMPTZ": "datetime",
     "_VARIANT": "json",
     "_OBJECT": "OBJECT",
-    "_ARRAY": "ARRAY"
+    "_ARRAY": "array"
 }

--- a/sqlconnect/internal/snowflake/testdata/legacy-column-mapping-test-columns-table.json
+++ b/sqlconnect/internal/snowflake/testdata/legacy-column-mapping-test-columns-table.json
@@ -31,5 +31,5 @@
     "_TIMESTAMPTZ": "datetime",
     "_VARIANT": "json",
     "_OBJECT": "OBJECT",
-    "_ARRAY": "ARRAY"
+    "_ARRAY": "array"
 }


### PR DESCRIPTION
# Description
We need to support operators on array data type for snowflake in audience builder. For need to be able to differentiate between json and array type. 
Columns type mappings have been updated for this

## Linear Ticket

Resolves REV-1088
https://linear.app/rudderstack/issue/REV-1088/[audiences][sources]-support-json-array-contains-for-snowflake

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
