### PR TITLE
fix: dialect quoting and normalisation inconsistencies

### DIFF
--- a/sqlconnect/internal/base/db.go
+++ b/sqlconnect/internal/base/db.go
@@ -32,7 +32,7 @@ func NewDB(db *sql.DB, tunnelCloser func() error, opts ...Option) *DB {
 				return "SELECT schema_name FROM information_schema.schemata", "schema_name"
 			},
 			SchemaExists: func(schema UnquotedIdentifier) string {
-				return fmt.Sprintf("SELECT schema_name FROM information_schema.schemata where schema_name = '%[1]s'", schema)
+				return fmt.Sprintf("SELECT schema_name FROM information_schema.schemata where schema_name = '%[1]s'", EscapeSqlString(schema))
 			},
 			DropSchema: func(schema QuotedIdentifier) string { return fmt.Sprintf("DROP SCHEMA %[1]s CASCADE", schema) },
 			CreateTestTable: func(table QuotedIdentifier) string {
@@ -40,21 +40,21 @@ func NewDB(db *sql.DB, tunnelCloser func() error, opts ...Option) *DB {
 			},
 			ListTables: func(schema UnquotedIdentifier) []lo.Tuple2[string, string] {
 				return []lo.Tuple2[string, string]{
-					{A: fmt.Sprintf("SELECT table_name FROM information_schema.tables WHERE table_schema = '%[1]s'", schema), B: "table_name"},
+					{A: fmt.Sprintf("SELECT table_name FROM information_schema.tables WHERE table_schema = '%[1]s'", EscapeSqlString(schema)), B: "table_name"},
 				}
 			},
 			ListTablesWithPrefix: func(schema UnquotedIdentifier, prefix string) []lo.Tuple2[string, string] {
 				return []lo.Tuple2[string, string]{
-					{A: fmt.Sprintf("SELECT table_name FROM information_schema.tables WHERE table_schema='%[1]s' AND table_name LIKE '%[2]s'", schema, prefix+"%"), B: "table_name"},
+					{A: fmt.Sprintf("SELECT table_name FROM information_schema.tables WHERE table_schema='%[1]s' AND table_name LIKE '%[2]s'", EscapeSqlString(schema), prefix+"%"), B: "table_name"},
 				}
 			},
 			TableExists: func(schema, table UnquotedIdentifier) string {
-				return fmt.Sprintf("SELECT table_name FROM information_schema.tables WHERE table_schema='%[1]s' and table_name = '%[2]s'", schema, table)
+				return fmt.Sprintf("SELECT table_name FROM information_schema.tables WHERE table_schema='%[1]s' and table_name = '%[2]s'", EscapeSqlString(schema), EscapeSqlString(table))
 			},
 			ListColumns: func(catalog, schema, table UnquotedIdentifier) (string, string, string) {
-				stmt := fmt.Sprintf("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = '%[1]s' AND table_name = '%[2]s'", schema, table)
+				stmt := fmt.Sprintf("SELECT column_name, data_type FROM information_schema.columns WHERE table_schema = '%[1]s' AND table_name = '%[2]s'", EscapeSqlString(schema), EscapeSqlString(table))
 				if catalog != "" {
-					stmt += fmt.Sprintf(" AND table_catalog = '%[1]s'", catalog)
+					stmt += fmt.Sprintf(" AND table_catalog = '%[1]s'", EscapeSqlString(catalog))
 				}
 				return stmt + " ORDER BY ordinal_position ASC", "column_name", "data_type"
 			},

--- a/sqlconnect/internal/base/dialect.go
+++ b/sqlconnect/internal/base/dialect.go
@@ -19,7 +19,7 @@ func (d dialect) QuoteTable(table sqlconnect.RelationRef) string {
 
 // QuoteIdentifier quotes an identifier, e.g. a column name
 func (d dialect) QuoteIdentifier(name string) string {
-	return fmt.Sprintf(`"%s"`, name)
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(name, `"`, `""`))
 }
 
 // FormatTableName formats a table name, typically by lower or upper casing it, depending on the database
@@ -98,4 +98,9 @@ func doNormaliseIdentifier(identifier string, quote rune, normF func(string) str
 		}
 	}
 	return result.String()
+}
+
+// EscapeSqlString escapes a string for use in SQL, e.g. by doubling single quotes
+func EscapeSqlString(value UnquotedIdentifier) string {
+	return strings.ReplaceAll(string(value), "'", "''")
 }

--- a/sqlconnect/internal/bigquery/db.go
+++ b/sqlconnect/internal/bigquery/db.go
@@ -55,12 +55,12 @@ func NewDB(configJSON json.RawMessage) (*DB, error) {
 					}
 				}
 				cmds.TableExists = func(schema, table base.UnquotedIdentifier) string {
-					return fmt.Sprintf("SELECT table_name FROM `%[1]s`.INFORMATION_SCHEMA.TABLES WHERE table_name = '%[2]s'", schema, table)
+					return fmt.Sprintf("SELECT table_name FROM `%[1]s`.INFORMATION_SCHEMA.TABLES WHERE table_name = '%[2]s'", schema, base.EscapeSqlString(table))
 				}
 				cmds.ListColumns = func(catalog, schema, table base.UnquotedIdentifier) (string, string, string) {
-					stmt := fmt.Sprintf("SELECT column_name, data_type FROM `%[1]s`.INFORMATION_SCHEMA.COLUMNS WHERE table_name = '%[2]s'", schema, table)
+					stmt := fmt.Sprintf("SELECT column_name, data_type FROM `%[1]s`.INFORMATION_SCHEMA.COLUMNS WHERE table_name = '%[2]s'", schema, base.EscapeSqlString(table))
 					if catalog != "" {
-						stmt += fmt.Sprintf(" AND table_catalog = '%[1]s'", catalog)
+						stmt += fmt.Sprintf(" AND table_catalog = '%[1]s'", base.EscapeSqlString(catalog))
 					}
 					return stmt, "column_name", "data_type"
 				}

--- a/sqlconnect/internal/bigquery/dialect_test.go
+++ b/sqlconnect/internal/bigquery/dialect_test.go
@@ -18,6 +18,8 @@ func TestDialect(t *testing.T) {
 	t.Run("quote identifier", func(t *testing.T) {
 		quoted := d.QuoteIdentifier("column")
 		require.Equal(t, "`column`", quoted, "column name should be quoted with backticks")
+
+		require.Equal(t, "`col\\`umn`", d.QuoteIdentifier("col`umn"), "column name with backtick should be escaped")
 	})
 
 	t.Run("quote table", func(t *testing.T) {
@@ -41,8 +43,8 @@ func TestDialect(t *testing.T) {
 		normalised = d.NormaliseIdentifier("TaBle.`ColUmn`")
 		require.Equal(t, "TaBle.`ColUmn`", normalised, "non quoted parts should be normalised")
 
-		normalised = d.NormaliseIdentifier("`Sh``EmA`.TABLE.`ColUmn`")
-		require.Equal(t, "`Sh``EmA`.TABLE.`ColUmn`", normalised, "non quoted parts should be normalised")
+		normalised = d.NormaliseIdentifier("`Sh\\`EmA`.TABLE.`Co\\'lUmn`")
+		require.Equal(t, "`Sh\\`EmA`.TABLE.`Co\\'lUmn`", normalised, "non quoted parts should be normalised")
 	})
 
 	t.Run("parse relation", func(t *testing.T) {
@@ -62,8 +64,8 @@ func TestDialect(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, sqlconnect.RelationRef{Schema: "ScHeMA", Name: "TaBle"}, parsed)
 
-		parsed, err = d.ParseRelationRef("`CaTa``LoG`.ScHeMA.`TaBle`")
+		parsed, err = d.ParseRelationRef("`CaTa``LoG`.ScHeMA.`TaB\\`\\\"\\'le`")
 		require.NoError(t, err)
-		require.Equal(t, sqlconnect.RelationRef{Catalog: "CaTa`LoG", Schema: "ScHeMA", Name: "TaBle"}, parsed)
+		require.Equal(t, sqlconnect.RelationRef{Catalog: "CaTa`LoG", Schema: "ScHeMA", Name: "TaB`\"'le"}, parsed)
 	})
 }

--- a/sqlconnect/internal/bigquery/integration_test.go
+++ b/sqlconnect/internal/bigquery/integration_test.go
@@ -24,7 +24,8 @@ func TestBigqueryDB(t *testing.T) {
 		[]byte(configJSON),
 		strings.ToLower,
 		integrationtest.Options{
-			LegacySupport: true,
+			LegacySupport:                  true,
+			SpecialCharactersInQuotedTable: "-",
 		},
 	)
 }

--- a/sqlconnect/internal/databricks/db.go
+++ b/sqlconnect/internal/databricks/db.go
@@ -77,14 +77,16 @@ func NewDB(configJson json.RawMessage) (*DB, error) {
 					return "SELECT current_catalog()"
 				}
 				cmds.ListSchemas = func() (string, string) { return "SHOW SCHEMAS", "schema_name" }
-				cmds.SchemaExists = func(schema base.UnquotedIdentifier) string { return fmt.Sprintf(`SHOW SCHEMAS LIKE '%s'`, schema) }
+				cmds.SchemaExists = func(schema base.UnquotedIdentifier) string {
+					return fmt.Sprintf(`SHOW SCHEMAS LIKE '%s'`, base.EscapeSqlString(schema))
+				}
 
 				cmds.CreateTestTable = func(table base.QuotedIdentifier) string {
 					return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %[1]s (c1 INT, c2 STRING)", table)
 				}
 				cmds.ListTables = func(schema base.UnquotedIdentifier) []lo.Tuple2[string, string] {
 					return []lo.Tuple2[string, string]{
-						{A: fmt.Sprintf("SHOW TABLES IN `%s`", schema), B: "tableName"},
+						{A: fmt.Sprintf("SHOW TABLES IN `%s`", base.EscapeSqlString(schema)), B: "tableName"},
 					}
 				}
 				cmds.ListTablesWithPrefix = func(schema base.UnquotedIdentifier, prefix string) []lo.Tuple2[string, string] {
@@ -93,7 +95,7 @@ func NewDB(configJson json.RawMessage) (*DB, error) {
 					}
 				}
 				cmds.TableExists = func(schema, table base.UnquotedIdentifier) string {
-					return fmt.Sprintf("SHOW TABLES IN `%[1]s` LIKE '%[2]s'", schema, table)
+					return fmt.Sprintf("SHOW TABLES IN `%[1]s` LIKE '%[2]s'", schema, base.EscapeSqlString(table))
 				}
 				cmds.ListColumns = func(catalog, schema, table base.UnquotedIdentifier) (string, string, string) {
 					if catalog == "" || !informationSchema {

--- a/sqlconnect/internal/databricks/integration_test.go
+++ b/sqlconnect/internal/databricks/integration_test.go
@@ -43,7 +43,8 @@ func TestDatabricksDB(t *testing.T) {
 			[]byte(configJSON),
 			strings.ToLower,
 			integrationtest.Options{
-				LegacySupport: true,
+				LegacySupport:                  true,
+				SpecialCharactersInQuotedTable: "`-",
 			},
 		)
 	})
@@ -63,7 +64,8 @@ func TestDatabricksDB(t *testing.T) {
 			[]byte(configJSON),
 			strings.ToLower,
 			integrationtest.Options{
-				LegacySupport: true,
+				LegacySupport:                  true,
+				SpecialCharactersInQuotedTable: "_A", // No special characters allowed
 			},
 		)
 

--- a/sqlconnect/internal/mysql/dialect.go
+++ b/sqlconnect/internal/mysql/dialect.go
@@ -19,7 +19,7 @@ func (d dialect) QuoteTable(table sqlconnect.RelationRef) string {
 
 // QuoteIdentifier quotes an identifier, e.g. a column name
 func (d dialect) QuoteIdentifier(name string) string {
-	return "`" + name + "`"
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
 }
 
 // FormatTableName formats a table name, typically by lower or upper casing it, depending on the database

--- a/sqlconnect/internal/redshift/dialect_test.go
+++ b/sqlconnect/internal/redshift/dialect_test.go
@@ -1,4 +1,4 @@
-package databricks
+package redshift
 
 import (
 	"testing"
@@ -17,15 +17,15 @@ func TestDialect(t *testing.T) {
 
 	t.Run("quote identifier", func(t *testing.T) {
 		quoted := d.QuoteIdentifier("column")
-		require.Equal(t, "`column`", quoted, "column name should be quoted with backticks")
+		require.Equal(t, `"column"`, quoted, "column name should be quoted with double quotes")
 	})
 
 	t.Run("quote table", func(t *testing.T) {
 		quoted := d.QuoteTable(sqlconnect.NewRelationRef("table"))
-		require.Equal(t, "`table`", quoted, "table name should be quoted with backticks")
+		require.Equal(t, `"table"`, quoted, "table name should be quoted with double quotes")
 
-		quoted = d.QuoteTable(sqlconnect.NewRelationRef("table", sqlconnect.WithSchema("schema")))
-		require.Equal(t, "`schema`.`table`", quoted, "schema and table name should be quoted with backticks")
+		quoted = d.QuoteTable(sqlconnect.NewSchemaTableRef("schema", "table"))
+		require.Equal(t, `"schema"."table"`, quoted, "schema and table name should be quoted with double quotes")
 	})
 
 	t.Run("normalise identifier", func(t *testing.T) {
@@ -35,18 +35,18 @@ func TestDialect(t *testing.T) {
 		normalised = d.NormaliseIdentifier("COLUMN")
 		require.Equal(t, "column", normalised, "column name should be normalised to lowercase")
 
-		normalised = d.NormaliseIdentifier("`ColUmn`")
-		require.Equal(t, "`column`", normalised, "quoted column name should be normalised to lowercase")
+		normalised = d.NormaliseIdentifier(`"ColUmn"`)
+		require.Equal(t, `"column"`, normalised, "quoted column name should be normalised to lowercase")
 
-		normalised = d.NormaliseIdentifier("TaBle.`ColUmn`")
-		require.Equal(t, "table.`column`", normalised, "all parts should be normalised")
+		normalised = d.NormaliseIdentifier(`TaBle."ColUmn"`)
+		require.Equal(t, `table."column"`, normalised, "all parts should be normalised")
 
-		normalised = d.NormaliseIdentifier("`Sh``EmA`.TABLE.`ColUmn`")
-		require.Equal(t, "`sh``ema`.table.`column`", normalised, "all parts should be normalised to lowercase")
+		normalised = d.NormaliseIdentifier(`"Sh""EmA".TABLE."ColUmn"`)
+		require.Equal(t, `"sh""ema".table."column"`, normalised, "all parts should be normalised")
 	})
 
 	t.Run("parse relation", func(t *testing.T) {
-		parsed, err := d.ParseRelationRef(`table`)
+		parsed, err := d.ParseRelationRef("table")
 		require.NoError(t, err)
 		require.Equal(t, sqlconnect.RelationRef{Name: "table"}, parsed)
 
@@ -54,16 +54,16 @@ func TestDialect(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, sqlconnect.RelationRef{Name: "table"}, parsed)
 
-		parsed, err = d.ParseRelationRef("`TaBle`")
+		parsed, err = d.ParseRelationRef(`"TaBle"`)
 		require.NoError(t, err)
-		require.Equal(t, sqlconnect.RelationRef{Name: "table"}, parsed)
+		require.Equal(t, sqlconnect.RelationRef{Name: `table`}, parsed)
 
-		parsed, err = d.ParseRelationRef("ScHeMA.`TaBle`")
+		parsed, err = d.ParseRelationRef(`ScHeMA."TaBle"`)
 		require.NoError(t, err)
 		require.Equal(t, sqlconnect.RelationRef{Schema: "schema", Name: "table"}, parsed)
 
-		parsed, err = d.ParseRelationRef("`CaTa``LoG`.ScHeMA.`TaBle`")
+		parsed, err = d.ParseRelationRef(`"CaTa""LoG".ScHeMA."TaBle"`)
 		require.NoError(t, err)
-		require.Equal(t, sqlconnect.RelationRef{Catalog: "cata`log", Schema: "schema", Name: "table"}, parsed)
+		require.Equal(t, sqlconnect.RelationRef{Catalog: "cata\"log", Schema: "schema", Name: "table"}, parsed)
 	})
 }

--- a/sqlconnect/internal/snowflake/db.go
+++ b/sqlconnect/internal/snowflake/db.go
@@ -47,7 +47,7 @@ func NewDB(configJSON json.RawMessage) (*DB, error) {
 				}
 				cmds.ListSchemas = func() (string, string) { return "SHOW TERSE SCHEMAS", "name" }
 				cmds.SchemaExists = func(schema base.UnquotedIdentifier) string {
-					return fmt.Sprintf("SHOW TERSE SCHEMAS LIKE '%[1]s'", schema)
+					return fmt.Sprintf("SHOW TERSE SCHEMAS LIKE '%[1]s'", base.EscapeSqlString(schema))
 				}
 				cmds.ListTables = func(schema base.UnquotedIdentifier) []lo.Tuple2[string, string] {
 					return []lo.Tuple2[string, string]{
@@ -61,7 +61,7 @@ func NewDB(configJSON json.RawMessage) (*DB, error) {
 					}
 				}
 				cmds.TableExists = func(schema, table base.UnquotedIdentifier) string {
-					return fmt.Sprintf("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '%[1]s' AND TABLE_NAME = '%[2]s'", schema, table)
+					return fmt.Sprintf("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = '%[1]s' AND TABLE_NAME = '%[2]s'", base.EscapeSqlString(schema), base.EscapeSqlString(table))
 				}
 				cmds.ListColumns = func(catalog, schema, table base.UnquotedIdentifier) (string, string, string) {
 					if catalog != "" {

--- a/sqlconnect/internal/snowflake/dialect.go
+++ b/sqlconnect/internal/snowflake/dialect.go
@@ -19,7 +19,7 @@ func (d dialect) QuoteTable(table sqlconnect.RelationRef) string {
 
 // QuoteIdentifier quotes an identifier, e.g. a column name
 func (d dialect) QuoteIdentifier(name string) string {
-	return `"` + name + `"`
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 // FormatTableName formats a table name, typically by lower or upper casing it, depending on the database

--- a/sqlconnect/internal/trino/db.go
+++ b/sqlconnect/internal/trino/db.go
@@ -45,6 +45,7 @@ func NewDB(configJSON json.RawMessage) (*DB, error) {
 		DB: base.NewDB(
 			db,
 			tunnelCloser,
+			base.WithDialect(dialect{}),
 			base.WithColumnTypeMapper(columnTypeMapper),
 			base.WithJsonRowMapper(jsonRowMapper),
 			base.WithSQLCommandsOverride(func(cmds base.SQLCommands) base.SQLCommands {
@@ -59,7 +60,7 @@ func NewDB(configJSON json.RawMessage) (*DB, error) {
 					}
 				}
 				cmds.TableExists = func(schema, table base.UnquotedIdentifier) string {
-					return fmt.Sprintf(`SHOW TABLES FROM "%[1]s" LIKE '%[2]s'`, schema, table)
+					return fmt.Sprintf(`SHOW TABLES FROM "%[1]s" LIKE '%[2]s'`, schema, base.EscapeSqlString(table))
 				}
 				cmds.TruncateTable = func(table base.QuotedIdentifier) string {
 					return fmt.Sprintf(`DELETE FROM %[1]s`, table)

--- a/sqlconnect/internal/trino/dialect.go
+++ b/sqlconnect/internal/trino/dialect.go
@@ -1,6 +1,7 @@
-package databricks
+package trino
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect"
@@ -19,7 +20,7 @@ func (d dialect) QuoteTable(table sqlconnect.RelationRef) string {
 
 // QuoteIdentifier quotes an identifier, e.g. a column name
 func (d dialect) QuoteIdentifier(name string) string {
-	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(name, `"`, `""`))
 }
 
 // FormatTableName formats a table name, typically by lower or upper casing it, depending on the database
@@ -29,15 +30,13 @@ func (d dialect) FormatTableName(name string) string {
 
 // NormaliseIdentifier normalises all identifier parts by lower casing them.
 func (d dialect) NormaliseIdentifier(identifier string) string {
-	// Identifiers are case-insensitive
-	// https://docs.databricks.com/en/sql/language-manual/sql-ref-identifiers.html#:~:text=Identifiers%20are%20case%2Dinsensitive
-	// Unity Catalog stores all object names as lowercase
-	// https://docs.databricks.com/en/sql/language-manual/sql-ref-names.html#:~:text=Unity%20Catalog%20stores%20all%20object%20names%20as%20lowercase
+	// Identifiers are not treated as case sensitive.
+	// https://trino.io/docs/current/language/reserved.html#:~:text=Identifiers%20are%20not%20treated%20as%20case%20sensitive.
 	return strings.ToLower(identifier)
 }
 
 // ParseRelationRef parses a string into a RelationRef after normalising the identifier and stripping out surrounding quotes.
 // The result is a RelationRef with case-sensitive fields, i.e. it can be safely quoted (see [QuoteTable] and, for instance, used for matching against the database's information schema.
 func (d dialect) ParseRelationRef(identifier string) (sqlconnect.RelationRef, error) {
-	return base.ParseRelationRef(strings.ToLower(identifier), '`', strings.ToLower)
+	return base.ParseRelationRef(strings.ToLower(identifier), '"', strings.ToLower)
 }

--- a/sqlconnect/internal/trino/dialect_test.go
+++ b/sqlconnect/internal/trino/dialect_test.go
@@ -1,4 +1,4 @@
-package databricks
+package trino
 
 import (
 	"testing"
@@ -17,15 +17,15 @@ func TestDialect(t *testing.T) {
 
 	t.Run("quote identifier", func(t *testing.T) {
 		quoted := d.QuoteIdentifier("column")
-		require.Equal(t, "`column`", quoted, "column name should be quoted with backticks")
+		require.Equal(t, `"column"`, quoted, "column name should be quoted with double quotes")
 	})
 
 	t.Run("quote table", func(t *testing.T) {
 		quoted := d.QuoteTable(sqlconnect.NewRelationRef("table"))
-		require.Equal(t, "`table`", quoted, "table name should be quoted with backticks")
+		require.Equal(t, `"table"`, quoted, "table name should be quoted with double quotes")
 
-		quoted = d.QuoteTable(sqlconnect.NewRelationRef("table", sqlconnect.WithSchema("schema")))
-		require.Equal(t, "`schema`.`table`", quoted, "schema and table name should be quoted with backticks")
+		quoted = d.QuoteTable(sqlconnect.NewSchemaTableRef("schema", "table"))
+		require.Equal(t, `"schema"."table"`, quoted, "schema and table name should be quoted with double quotes")
 	})
 
 	t.Run("normalise identifier", func(t *testing.T) {
@@ -35,18 +35,18 @@ func TestDialect(t *testing.T) {
 		normalised = d.NormaliseIdentifier("COLUMN")
 		require.Equal(t, "column", normalised, "column name should be normalised to lowercase")
 
-		normalised = d.NormaliseIdentifier("`ColUmn`")
-		require.Equal(t, "`column`", normalised, "quoted column name should be normalised to lowercase")
+		normalised = d.NormaliseIdentifier(`"ColUmn"`)
+		require.Equal(t, `"column"`, normalised, "quoted column name should be normalised to lowercase")
 
-		normalised = d.NormaliseIdentifier("TaBle.`ColUmn`")
-		require.Equal(t, "table.`column`", normalised, "all parts should be normalised")
+		normalised = d.NormaliseIdentifier(`TaBle."ColUmn"`)
+		require.Equal(t, `table."column"`, normalised, "all parts should be normalised")
 
-		normalised = d.NormaliseIdentifier("`Sh``EmA`.TABLE.`ColUmn`")
-		require.Equal(t, "`sh``ema`.table.`column`", normalised, "all parts should be normalised to lowercase")
+		normalised = d.NormaliseIdentifier(`"Sh""EmA".TABLE."ColUmn"`)
+		require.Equal(t, `"sh""ema".table."column"`, normalised, "all parts should be normalised")
 	})
 
 	t.Run("parse relation", func(t *testing.T) {
-		parsed, err := d.ParseRelationRef(`table`)
+		parsed, err := d.ParseRelationRef("table")
 		require.NoError(t, err)
 		require.Equal(t, sqlconnect.RelationRef{Name: "table"}, parsed)
 
@@ -54,16 +54,16 @@ func TestDialect(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, sqlconnect.RelationRef{Name: "table"}, parsed)
 
-		parsed, err = d.ParseRelationRef("`TaBle`")
+		parsed, err = d.ParseRelationRef(`"TaBle"`)
 		require.NoError(t, err)
-		require.Equal(t, sqlconnect.RelationRef{Name: "table"}, parsed)
+		require.Equal(t, sqlconnect.RelationRef{Name: `table`}, parsed)
 
-		parsed, err = d.ParseRelationRef("ScHeMA.`TaBle`")
+		parsed, err = d.ParseRelationRef(`ScHeMA."TaBle"`)
 		require.NoError(t, err)
 		require.Equal(t, sqlconnect.RelationRef{Schema: "schema", Name: "table"}, parsed)
 
-		parsed, err = d.ParseRelationRef("`CaTa``LoG`.ScHeMA.`TaBle`")
+		parsed, err = d.ParseRelationRef(`"CaTa""LoG".ScHeMA."TaBle"`)
 		require.NoError(t, err)
-		require.Equal(t, sqlconnect.RelationRef{Catalog: "cata`log", Schema: "schema", Name: "table"}, parsed)
+		require.Equal(t, sqlconnect.RelationRef{Catalog: "cata\"log", Schema: "schema", Name: "table"}, parsed)
 	})
 }

--- a/sqlconnect/internal/trino/integration_test.go
+++ b/sqlconnect/internal/trino/integration_test.go
@@ -24,7 +24,9 @@ func TestTrinoDB(t *testing.T) {
 		trino.DatabaseType,
 		[]byte(configJSON),
 		strings.ToLower,
-		integrationtest.Options{},
+		integrationtest.Options{
+			SpecialCharactersInQuotedTable: "_12", // No special characters allowed in table names :/
+		},
 	)
 
 	integrationtest.TestSshTunnelScenarios(t, trino.DatabaseType, []byte(configJSON))

--- a/sqlconnect/querydef_test.go
+++ b/sqlconnect/querydef_test.go
@@ -2,6 +2,7 @@ package sqlconnect_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,7 +55,7 @@ func (d testDialect) FormatTableName(name string) string {
 }
 
 func (d testDialect) QuoteIdentifier(name string) string {
-	return fmt.Sprintf(`"%s"`, name)
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(name, `"`, `""`))
 }
 
 func (d testDialect) QuoteTable(relation sqlconnect.RelationRef) string {


### PR DESCRIPTION
# Description

- Escaping quotes in identifiers during `Dialect#QuoteIdentifier` for all warehouses.
- Identifiers in `redshift`, `trino` and `databricks` are case-insensitive and should be folded to lowercase regardless if they are quoted or not.
- Handle case in `redshift` when `enable_case_sensitive_identifier: on`.
- Adding a scenario to verify that all dialects treat quoted tables properly for all warehouses.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
