### PR TITLE
fix(redshift): dialect#parserelationref doesn't honour enable_case_sensitive_identifier

### DIFF
--- a/sqlconnect/internal/redshift/dialect.go
+++ b/sqlconnect/internal/redshift/dialect.go
@@ -43,5 +43,6 @@ func (d dialect) NormaliseIdentifier(identifier string) string {
 // ParseRelationRef parses a string into a RelationRef after normalising the identifier and stripping out surrounding quotes.
 // The result is a RelationRef with case-sensitive fields, i.e. it can be safely quoted (see [QuoteTable] and, for instance, used for matching against the database's information schema.
 func (d dialect) ParseRelationRef(identifier string) (sqlconnect.RelationRef, error) {
-	return base.ParseRelationRef(strings.ToLower(identifier), '"', strings.ToLower)
+	identifier = d.NormaliseIdentifier(identifier)
+	return base.ParseRelationRef(identifier, '"', strings.ToLower)
 }

--- a/sqlconnect/internal/redshift/dialect_test.go
+++ b/sqlconnect/internal/redshift/dialect_test.go
@@ -43,6 +43,25 @@ func TestDialect(t *testing.T) {
 
 		normalised = d.NormaliseIdentifier(`"Sh""EmA".TABLE."ColUmn"`)
 		require.Equal(t, `"sh""ema".table."column"`, normalised, "all parts should be normalised")
+
+		t.Run("case sensitive", func(t *testing.T) {
+			d := dialect{caseSensitive: true}
+
+			normalised := d.NormaliseIdentifier("column")
+			require.Equal(t, "column", normalised, "column name should be normalised to lowercase")
+
+			normalised = d.NormaliseIdentifier("COLUMN")
+			require.Equal(t, "column", normalised, "column name should be normalised to lowercase")
+
+			normalised = d.NormaliseIdentifier(`"ColUmn"`)
+			require.Equal(t, `"ColUmn"`, normalised, "quoted column name should be preserved")
+
+			normalised = d.NormaliseIdentifier(`TaBle."ColUmn"`)
+			require.Equal(t, `table."ColUmn"`, normalised, "unquoted parts should be normalised")
+
+			normalised = d.NormaliseIdentifier(`"Sh""EmA".TABLE."ColUmn"`)
+			require.Equal(t, `"Sh""EmA".table."ColUmn"`, normalised, "unquoted parts should be normalised")
+		})
 	})
 
 	t.Run("parse relation", func(t *testing.T) {
@@ -65,5 +84,29 @@ func TestDialect(t *testing.T) {
 		parsed, err = d.ParseRelationRef(`"CaTa""LoG".ScHeMA."TaBle"`)
 		require.NoError(t, err)
 		require.Equal(t, sqlconnect.RelationRef{Catalog: "cata\"log", Schema: "schema", Name: "table"}, parsed)
+
+		t.Run("case sensitive", func(t *testing.T) {
+			d := dialect{caseSensitive: true}
+
+			parsed, err := d.ParseRelationRef("table")
+			require.NoError(t, err)
+			require.Equal(t, sqlconnect.RelationRef{Name: "table"}, parsed)
+
+			parsed, err = d.ParseRelationRef("TABLE")
+			require.NoError(t, err)
+			require.Equal(t, sqlconnect.RelationRef{Name: "table"}, parsed)
+
+			parsed, err = d.ParseRelationRef(`"TaBle"`)
+			require.NoError(t, err)
+			require.Equal(t, sqlconnect.RelationRef{Name: `TaBle`}, parsed)
+
+			parsed, err = d.ParseRelationRef(`ScHeMA."TaBle"`)
+			require.NoError(t, err)
+			require.Equal(t, sqlconnect.RelationRef{Schema: "schema", Name: "TaBle"}, parsed)
+
+			parsed, err = d.ParseRelationRef(`"CaTa""LoG".ScHeMA."TaBle"`)
+			require.NoError(t, err)
+			require.Equal(t, sqlconnect.RelationRef{Catalog: "CaTa\"LoG", Schema: "schema", Name: "TaBle"}, parsed)
+		})
 	})
 }


### PR DESCRIPTION
# Description

Using `Dialect#NormaliseIdentifier` from within `Dialect#ParseRelationRef`

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
