### PR TITLE
chore: all warehouses support views in ListTables

### DIFF
--- a/sqlconnect/internal/snowflake/integration_test.go
+++ b/sqlconnect/internal/snowflake/integration_test.go
@@ -24,8 +24,7 @@ func TestSnowflakeDB(t *testing.T) {
 		[]byte(configJSON),
 		strings.ToUpper,
 		integrationtest.Options{
-			LegacySupport:             true,
-			IncludesViewsInListTables: true,
+			LegacySupport: true,
 		},
 	)
 }


### PR DESCRIPTION
# Description

- Removed unnecessary `IncludesViewsInListTables` flag from integration tests
- Added a scenario for verifying that view's columns are returned during `ListColumns`

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
