### PR TITLE
fix(bigquery): goqu dialect is not registered

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	github.com/ory/dockertest/v3 v3.11.0
-	github.com/rudderlabs/goqu/v10 v10.3.0
+	github.com/rudderlabs/goqu/v10 v10.3.1
 	github.com/rudderlabs/rudder-go-kit v0.42.0
 	github.com/rudderlabs/sql-tunnels v0.1.7
 	github.com/samber/lo v1.47.0

--- a/go.sum
+++ b/go.sum
@@ -301,8 +301,8 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
 github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
-github.com/rudderlabs/goqu/v10 v10.3.0 h1:FaZioS8fRYJVYoLO5lieuyiVvEHhmQ6jP5sKwPIcKSs=
-github.com/rudderlabs/goqu/v10 v10.3.0/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
+github.com/rudderlabs/goqu/v10 v10.3.1 h1:rnfX+b4EwBWQ2UQfIGeEW299JBBkK5biEbnf7Kq4/Gg=
+github.com/rudderlabs/goqu/v10 v10.3.1/go.mod h1:LH2vI5gGHBxEQuESqFyk5ZA2anGINc8o25hbidDWOYw=
 github.com/rudderlabs/rudder-go-kit v0.42.0 h1:j84n8y+iQ7amCuZ5s5Lq+T6DTgSaQsxbKYocZx8ouZQ=
 github.com/rudderlabs/rudder-go-kit v0.42.0/go.mod h1:CbDfW+wgQJ/A+5iqOWFv/Allo1SDNOgGOd1Y+uOuz0k=
 github.com/rudderlabs/sql-tunnels v0.1.7 h1:wDCRl6zY4M5gfWazf7XkSTGQS3yjBzUiUgEMBIfHNDA=

--- a/sqlconnect/internal/bigquery/goqu_dialect.go
+++ b/sqlconnect/internal/bigquery/goqu_dialect.go
@@ -9,6 +9,10 @@ import (
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/base"
 )
 
+func init() {
+	goqu.RegisterDialect(DatabaseType, GoquDialectOptions())
+}
+
 func GoquDialectOptions() *sqlgen.SQLDialectOptions {
 	o := sqlgen.DefaultDialectOptions()
 	o.QuoteIdentifiers = false


### PR DESCRIPTION
# Description

- Registering missing bigquery dialect for goqu.
- Bumping goqu to 10.3.1 to fix an issue with double parenthesis

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
