### PR TITLE
chore: bump go version to 1.23

### DIFF
--- a/.github/workflows/cleanup-test-schemas.yaml
+++ b/.github/workflows/cleanup-test-schemas.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           check-latest: true
       - run: go version
       - run: go mod download

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           check-latest: true
       - run: go version
       - run: go mod download
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
           check-latest: true
       - name: Download coverage reports
         uses: actions/download-artifact@v4

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           check-latest: true
           cache: true
-          go-version: 1.22
+          go-version: 1.23
       - run: go version
 
       - run: go mod tidy
@@ -44,13 +44,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.23
           check-latest: true
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.2
+          version: v1.61.0
           args: 
             -v
             --timeout 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 10m
-  go: '1.22'
+  go: '1.23'
 
 linters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ install-tools:
 	go install mvdan.cc/gofumpt@latest
 	go install gotest.tools/gotestsum@v1.8.2
 	go install golang.org/x/tools/cmd/goimports@latest
-	bash ./internal/scripts/install-golangci-lint.sh v1.56.2
+	bash ./internal/scripts/install-golangci-lint.sh v1.61.0
 
 .PHONY: lint
 lint: fmt ## Run linters on all go files

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rudderlabs/sqlconnect-go
 
-go 1.22.7
+go 1.23.2
 
 require (
 	cloud.google.com/go v0.115.1


### PR DESCRIPTION
# Description

Bumping Go version to 1.23

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
