### PR TITLE
feat(databricks): normalize column names

### DIFF
--- a/sqlconnect/internal/databricks/config.go
+++ b/sqlconnect/internal/databricks/config.go
@@ -27,6 +27,12 @@ type Config struct {
 	SessionParams map[string]string `json:"sessionParams"`
 
 	UseLegacyMappings bool `json:"useLegacyMappings"`
+	// SkipColumnNormalization skips normalizing column names during ListColumns and ListColumnsForSqlQuery.
+	// Databricks is returning column names case sensitive from information schema, even though it is case insensitive.
+	// So, by default table names are returned normalized by databricks, whereas column names are not.
+	// To avoid this inconsistency, we are normalizing column names by default.
+	// If you want to skip this normalization, set this flag to true.
+	SkipColumnNormalization bool `json:"skipColumnNormalisation"`
 }
 
 func (c *Config) Parse(input json.RawMessage) error {

--- a/sqlconnect/internal/databricks/db.go
+++ b/sqlconnect/internal/databricks/db.go
@@ -120,7 +120,8 @@ func NewDB(configJson json.RawMessage) (*DB, error) {
 				return cmds
 			}),
 		),
-		informationSchema: informationSchema,
+		informationSchema:       informationSchema,
+		skipColumnNormalization: config.SkipColumnNormalization,
 	}, nil
 }
 
@@ -132,7 +133,8 @@ func init() {
 
 type DB struct {
 	*base.DB
-	informationSchema bool
+	informationSchema       bool
+	skipColumnNormalization bool
 }
 
 func getColumnTypeMapper(config Config) func(base.ColumnType) string {


### PR DESCRIPTION
# Description

The default behaviour of databricks is to return column names case sensitive when one queries the information schema, even though it treats them as case insensitive in sql statements. 
For table names, databricks behaviour is different, it stores them in lowercase. 
So, by default, table names are returned normalized by databricks, whereas column names are not.
To avoid this inconsistency, we are now normalizing column names as default behaviour.

Users who wish to avoid this behavioural change, they can set the `SkipColumnNormalization` configuration flag to `true`.

## Linear Ticket

resolves PRO-3980

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
