### PR TITLE
chore: exclude trino from cleanup

### DIFF
--- a/sqlconnect/cmd/cleanup/cleanup.go
+++ b/sqlconnect/cmd/cleanup/cleanup.go
@@ -14,7 +14,6 @@ import (
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/databricks"
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/redshift"
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/snowflake"
-	"github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/trino"
 )
 
 func main() {
@@ -31,7 +30,7 @@ func main() {
 		{Env: "REDSHIFT_DATA_TEST_ENVIRONMENT_CREDENTIALS", Type: redshift.DatabaseType},
 		{Env: "REDSHIFT_TEST_ENVIRONMENT_CREDENTIALS", Type: redshift.DatabaseType},
 		{Env: "SNOWFLAKE_TEST_ENVIRONMENT_CREDENTIALS", Type: snowflake.DatabaseType},
-		{Env: "TRINO_TEST_ENVIRONMENT_CREDENTIALS", Type: trino.DatabaseType},
+		// {Env: "TRINO_TEST_ENVIRONMENT_CREDENTIALS", Type: trino.DatabaseType},
 	}
 
 	g, ctx := errgroup.WithContext(context.Background())


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks 8.30.1

# Description

Exclude trino from cleanup, since we are no longer running trino tests and credentials are invalid

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
