### PR TITLE
feat(array): map array<string> warehouse columns + serialize as JSON arrays

### DIFF
--- a/sqlconnect/internal/bigquery/driver/columns.go
+++ b/sqlconnect/internal/bigquery/driver/columns.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"database/sql/driver"
+	"fmt"
 
 	"cloud.google.com/go/bigquery"
 )
@@ -34,7 +35,10 @@ func (columns bigQueryColumns) ColumnTypeDatabaseTypeName(index int) string {
 	if index > -1 && len(columns.columns) > index {
 		column := columns.columns[index]
 		if column.FieldSchema.Repeated {
-			return "ARRAY"
+			// Carry the element type (e.g. ARRAY<STRING>) so the result-set/live path matches what
+			// INFORMATION_SCHEMA reports on the catalog path; element-aware type mapping (string
+			// arrays → the array rudder-type) depends on it. A bare "ARRAY" collapses to json.
+			return fmt.Sprintf("ARRAY<%s>", column.FieldSchema.Type)
 		}
 		return string(column.FieldSchema.Type)
 	}

--- a/sqlconnect/internal/bigquery/driver/driver_test.go
+++ b/sqlconnect/internal/bigquery/driver/driver_test.go
@@ -152,7 +152,7 @@ func TestBigqueryDriver(t *testing.T) {
 			require.NoError(t, err, "it should be able to get the column types")
 			require.Len(t, colTypes, 2, "it should be able to get the correct number of column types")
 			require.EqualValues(t, "INTEGER", colTypes[0].DatabaseTypeName(), "it should be able to get the correct column type")
-			require.EqualValues(t, "ARRAY", colTypes[1].DatabaseTypeName(), "it should be able to get the correct column type")
+			require.EqualValues(t, "ARRAY<STRING>", colTypes[1].DatabaseTypeName(), "the element type must be carried so string arrays map to the array rudder-type")
 
 			require.True(t, rows.Next(), "it should be able to get a row")
 			var c1 int

--- a/sqlconnect/internal/bigquery/mappings.go
+++ b/sqlconnect/internal/bigquery/mappings.go
@@ -54,8 +54,17 @@ var columnTypeMappings = map[string]string{
 
 var re = regexp.MustCompile(`(\(.+\)|<.+>)`) // remove type parameters [<>] and size constraints [()]
 
+// stringElementArray matches ARRAY<STRING|BYTES ...> — string-element arrays map to the array
+// rudder-type in v1 (checked before the type-parameter strip). Other element types (e.g.
+// ARRAY<INT64>) fall through to the generic ARRAY → json mapping (surfaced as unsupported).
+var stringElementArray = regexp.MustCompile(`^ARRAY<\s*(STRING|BYTES)`)
+
 func columnTypeMapper(columnType base.ColumnType) string {
-	databaseTypeName := strings.ToUpper(re.ReplaceAllString(columnType.DatabaseTypeName(), ""))
+	raw := strings.ToUpper(columnType.DatabaseTypeName())
+	if stringElementArray.MatchString(raw) {
+		return "array"
+	}
+	databaseTypeName := strings.ToUpper(re.ReplaceAllString(raw, ""))
 	if mappedType, ok := columnTypeMappings[strings.ToUpper(databaseTypeName)]; ok {
 		return mappedType
 	}

--- a/sqlconnect/internal/bigquery/mappings_array_test.go
+++ b/sqlconnect/internal/bigquery/mappings_array_test.go
@@ -1,0 +1,16 @@
+package bigquery
+
+import ("testing"; "github.com/stretchr/testify/require")
+
+type mockCT struct{ n string }
+func (m mockCT) DatabaseTypeName() string { return m.n }
+func (mockCT) DecimalSize() (int64, int64, bool) { return 0, 0, false }
+
+func TestColumnTypeMapper_Array(t *testing.T) {
+	for _, raw := range []string{"ARRAY<STRING>", "array<string>", "ARRAY<BYTES>"} {
+		require.Equal(t, "array", columnTypeMapper(mockCT{raw}), raw)
+	}
+	require.Equal(t, "json", columnTypeMapper(mockCT{"ARRAY<INT64>"}), "non-string array stays json")
+	require.Equal(t, "string", columnTypeMapper(mockCT{"STRING"}))
+	require.Equal(t, "json", columnTypeMapper(mockCT{"STRUCT<a INT64>"}))
+}

--- a/sqlconnect/internal/bigquery/mappings_array_test.go
+++ b/sqlconnect/internal/bigquery/mappings_array_test.go
@@ -1,9 +1,14 @@
 package bigquery
 
-import ("testing"; "github.com/stretchr/testify/require")
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 type mockCT struct{ n string }
-func (m mockCT) DatabaseTypeName() string { return m.n }
+
+func (m mockCT) DatabaseTypeName() string        { return m.n }
 func (mockCT) DecimalSize() (int64, int64, bool) { return 0, 0, false }
 
 func TestColumnTypeMapper_Array(t *testing.T) {

--- a/sqlconnect/internal/bigquery/testdata/column-mapping-test-columns.json
+++ b/sqlconnect/internal/bigquery/testdata/column-mapping-test-columns.json
@@ -1,6 +1,6 @@
 {
     "_order": "int",
-    "_array": "json",
+    "_array": "array",
     "_bignumeric": "float",
     "_bignumericnoscale": "float",
     "_bigdecimal": "float",

--- a/sqlconnect/internal/databricks/legacy_mappings.go
+++ b/sqlconnect/internal/databricks/legacy_mappings.go
@@ -31,7 +31,14 @@ func legacyColumnTypeMapper(columnType base.ColumnType) string {
 		"MAP":           "json",
 		"STRUCT":        "json",
 	}
-	databaseTypeName := strings.ToUpper(re.ReplaceAllString(columnType.DatabaseTypeName(), ""))
+	raw := strings.ToUpper(columnType.DatabaseTypeName())
+	// String-element arrays map to the array rudder-type (checked before the type-parameter
+	// strip); other element types fall through to the generic ARRAY → json mapping. Mirrors
+	// the non-legacy columnTypeMapper so the schema path (useStandardTypeMappings) agrees.
+	if stringElementArray.MatchString(raw) {
+		return "array"
+	}
+	databaseTypeName := strings.ToUpper(re.ReplaceAllString(raw, ""))
 	if mappedType, ok := columnTypeMappings[strings.ToUpper(databaseTypeName)]; ok {
 		return mappedType
 	}

--- a/sqlconnect/internal/databricks/mappings.go
+++ b/sqlconnect/internal/databricks/mappings.go
@@ -49,8 +49,17 @@ var columnTypeMappings = map[string]string{
 
 var re = regexp.MustCompile(`(\(.+\)|<.+>)`) // remove type parameters [<>] and size constraints [()]
 
+// stringElementArray matches ARRAY<STRING|VARCHAR|CHAR ...> — string-element arrays
+// that map to the array rudder-type in v1. Other element types (e.g. ARRAY<BIGINT>)
+// fall through to the generic ARRAY → json mapping (surfaced as unsupported).
+var stringElementArray = regexp.MustCompile(`^ARRAY<\s*(STRING|VARCHAR|CHAR)`)
+
 func columnTypeMapper(columnType base.ColumnType) string {
-	databaseTypeName := strings.ToUpper(re.ReplaceAllString(columnType.DatabaseTypeName(), ""))
+	raw := strings.ToUpper(columnType.DatabaseTypeName())
+	if stringElementArray.MatchString(raw) {
+		return "array"
+	}
+	databaseTypeName := strings.ToUpper(re.ReplaceAllString(raw, ""))
 	if mappedType, ok := columnTypeMappings[strings.ToUpper(databaseTypeName)]; ok {
 		return mappedType
 	}

--- a/sqlconnect/internal/databricks/mappings_test.go
+++ b/sqlconnect/internal/databricks/mappings_test.go
@@ -1,0 +1,37 @@
+package databricks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// mockColumnType implements base.ColumnType for testing the column type mapper.
+type mockColumnType struct {
+	databaseTypeName string
+}
+
+func (m mockColumnType) DatabaseTypeName() string { return m.databaseTypeName }
+func (m mockColumnType) DecimalSize() (precision, scale int64, ok bool) {
+	return 0, 0, false
+}
+
+func TestColumnTypeMapper_Array(t *testing.T) {
+	t.Run("string-element arrays map to array rudder-type", func(t *testing.T) {
+		for _, raw := range []string{"ARRAY<STRING>", "array<string>", "ARRAY<VARCHAR(255)>", "ARRAY<CHAR(3)>"} {
+			require.Equal(t, "array", columnTypeMapper(mockColumnType{raw}), raw)
+		}
+	})
+
+	t.Run("non-string-element arrays stay json (unsupported in v1)", func(t *testing.T) {
+		for _, raw := range []string{"ARRAY<BIGINT>", "ARRAY<INT>", "ARRAY<DOUBLE>", "ARRAY<STRUCT<a:INT>>"} {
+			require.Equal(t, "json", columnTypeMapper(mockColumnType{raw}), raw)
+		}
+	})
+
+	t.Run("scalar types unaffected", func(t *testing.T) {
+		require.Equal(t, "string", columnTypeMapper(mockColumnType{"STRING"}))
+		require.Equal(t, "int", columnTypeMapper(mockColumnType{"BIGINT"}))
+		require.Equal(t, "json", columnTypeMapper(mockColumnType{"MAP<STRING,INT>"}))
+	})
+}

--- a/sqlconnect/internal/databricks/mappings_test.go
+++ b/sqlconnect/internal/databricks/mappings_test.go
@@ -35,3 +35,15 @@ func TestColumnTypeMapper_Array(t *testing.T) {
 		require.Equal(t, "json", columnTypeMapper(mockColumnType{"MAP<STRING,INT>"}))
 	})
 }
+
+// The data-graph schema path (useStandardTypeMappings) uses the legacy mapper, so it must
+// agree with columnTypeMapper on string-element arrays (DESCRIBE TABLE yields the full type).
+func TestLegacyColumnTypeMapper_Array(t *testing.T) {
+	for _, raw := range []string{"ARRAY<STRING>", "array<string>", "ARRAY<VARCHAR(255)>"} {
+		require.Equal(t, "array", legacyColumnTypeMapper(mockColumnType{raw}), raw)
+	}
+	for _, raw := range []string{"ARRAY<BIGINT>", "ARRAY<INT>"} {
+		require.Equal(t, "json", legacyColumnTypeMapper(mockColumnType{raw}), raw)
+	}
+	require.Equal(t, "string", legacyColumnTypeMapper(mockColumnType{"STRING"}))
+}

--- a/sqlconnect/internal/postgres/legacy_mappings.go
+++ b/sqlconnect/internal/postgres/legacy_mappings.go
@@ -31,6 +31,18 @@ var legacyColumnTypeMappings = map[string]string{
 	"boolean":                     "boolean",
 	"bool":                        "boolean",
 	"jsonb":                       "json",
+	// Array columns. The standard schema introspection (ListColumns) reads
+	// information_schema.columns.data_type, which reports the generic "ARRAY" for every array
+	// column regardless of element type (element type lives in udt_name, not selected here).
+	// So this maps ALL Postgres arrays to the array rudder-type; element-type precision
+	// (string-only) is enforced on the data path via columnTypeMappings (_text etc). The
+	// "_text" udt family is also mapped for any caller that introspects via udt_name.
+	"array":    "array",
+	"_text":    "array",
+	"_varchar": "array",
+	"_bpchar":  "array",
+	"_char":    "array",
+	"_name":    "array",
 }
 
 // legacyJsonRowMapper maps a row's scanned column to a json object's field

--- a/sqlconnect/internal/postgres/legacy_mappings.go
+++ b/sqlconnect/internal/postgres/legacy_mappings.go
@@ -1,6 +1,9 @@
 package postgres
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 var legacyColumnTypeMappings = map[string]string{
 	"int":                         "int",
@@ -59,6 +62,11 @@ func legacyJsonRowMapper(databaseTypeName string, value any) any {
 			return json.RawMessage(v)
 		}
 	default:
+		if pgStringArrayTypes[strings.ToUpper(databaseTypeName)] {
+			if arr := parsePgStringArray(value); arr != nil {
+				return arr
+			}
+		}
 		switch v := value.(type) {
 		case []byte:
 			return string(v)

--- a/sqlconnect/internal/postgres/mappings.go
+++ b/sqlconnect/internal/postgres/mappings.go
@@ -41,6 +41,15 @@ var columnTypeMappings = map[string]string{
 	"bool":                        "boolean",
 	"json":                        "json",
 	"jsonb":                       "json",
+	// String-element array types (Postgres reports array columns as the element type
+	// prefixed with "_"). Only string arrays map to the array rudder-type in v1;
+	// non-string array types (e.g. _int4) stay unmapped → surfaced as unsupported.
+	"_text":              "array",
+	"_varchar":           "array",
+	"_bpchar":            "array",
+	"_char":              "array",
+	"_character varying": "array",
+	"_name":              "array",
 }
 
 // jsonRowMapper maps a row's scanned column to a json object's field

--- a/sqlconnect/internal/postgres/mappings.go
+++ b/sqlconnect/internal/postgres/mappings.go
@@ -3,7 +3,35 @@ package postgres
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
+
+	"github.com/lib/pq"
 )
+
+// pgStringArrayTypes are the Postgres string-element array type names (element type prefixed
+// with "_"). Their values are parsed from the array literal into a JSON array of strings so
+// the emitted trait is a real JSON array, not the text literal "{a,b}".
+var pgStringArrayTypes = map[string]bool{
+	"_TEXT": true, "_VARCHAR": true, "_BPCHAR": true, "_CHAR": true, "_NAME": true, "_CHARACTER VARYING": true,
+}
+
+// parsePgStringArray parses a Postgres array literal ("{a,b}") into a []string. Returns nil
+// (caller falls through) if the value isn't a parseable array literal. A NULL array column
+// scans to nil and is left as nil (→ JSON null).
+func parsePgStringArray(value any) any {
+	var arr pq.StringArray
+	switch v := value.(type) {
+	case []byte:
+		if arr.Scan(v) == nil {
+			return []string(arr)
+		}
+	case string:
+		if arr.Scan([]byte(v)) == nil {
+			return []string(arr)
+		}
+	}
+	return nil
+}
 
 // mapping of database column types to rudder types
 var columnTypeMappings = map[string]string{
@@ -73,6 +101,11 @@ func jsonRowMapper(databaseTypeName string, value any) any {
 			}
 		}
 	default:
+		if pgStringArrayTypes[strings.ToUpper(databaseTypeName)] {
+			if arr := parsePgStringArray(value); arr != nil {
+				return arr
+			}
+		}
 		switch v := value.(type) {
 		case []byte:
 			return string(v)

--- a/sqlconnect/internal/postgres/mappings.go
+++ b/sqlconnect/internal/postgres/mappings.go
@@ -41,9 +41,12 @@ var columnTypeMappings = map[string]string{
 	"bool":                        "boolean",
 	"json":                        "json",
 	"jsonb":                       "json",
-	// String-element array types (Postgres reports array columns as the element type
-	// prefixed with "_"). Only string arrays map to the array rudder-type in v1;
-	// non-string array types (e.g. _int4) stay unmapped → surfaced as unsupported.
+	// Array columns. On the data path (row scan) Postgres reports the element type prefixed
+	// with "_" (e.g. text[] → "_text"), so only string-element arrays map to array — non-string
+	// array types (e.g. _int4) stay unmapped → unsupported. The generic "array" key covers
+	// schema introspection via information_schema.data_type, which reports "ARRAY" for every
+	// array column (no element type available there).
+	"array":              "array",
 	"_text":              "array",
 	"_varchar":           "array",
 	"_bpchar":            "array",

--- a/sqlconnect/internal/postgres/mappings.go
+++ b/sqlconnect/internal/postgres/mappings.go
@@ -18,6 +18,10 @@ var pgStringArrayTypes = map[string]bool{
 // parsePgStringArray parses a Postgres array literal ("{a,b}") into a []string. Returns nil
 // (caller falls through) if the value isn't a parseable array literal. A NULL array column
 // scans to nil and is left as nil (→ JSON null).
+//
+// Caveat: pq.StringArray cannot represent a NULL *element* — a literal like "{NULL,a}" fails to
+// scan, so the value falls through to the raw literal string rather than a JSON array. v1 targets
+// homogeneous non-null string tags, where NULL elements don't occur; revisit if that changes.
 func parsePgStringArray(value any) any {
 	var arr pq.StringArray
 	switch v := value.(type) {

--- a/sqlconnect/internal/postgres/mappings_test.go
+++ b/sqlconnect/internal/postgres/mappings_test.go
@@ -1,0 +1,29 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Postgres resolves rudder-types via base.dbopts using
+// columnTypeMappings[strings.ToLower(DatabaseTypeName())]. Array columns report
+// their element type prefixed with "_" (e.g. text[] → "_text").
+func TestColumnTypeMappings_Array(t *testing.T) {
+	t.Run("string-element array types map to array", func(t *testing.T) {
+		for _, name := range []string{"_text", "_varchar", "_bpchar", "_char", "_name"} {
+			require.Equal(t, "array", columnTypeMappings[name], name)
+		}
+	})
+
+	t.Run("non-string array types are not mapped (unsupported in v1)", func(t *testing.T) {
+		for _, name := range []string{"_int4", "_int8", "_float8", "_bool", "_timestamp"} {
+			_, ok := columnTypeMappings[name]
+			require.False(t, ok, "%s must not map to a supported rudder-type", name)
+		}
+	})
+
+	t.Run("scalar text stays string", func(t *testing.T) {
+		require.Equal(t, "string", columnTypeMappings["text"])
+	})
+}

--- a/sqlconnect/internal/postgres/mappings_test.go
+++ b/sqlconnect/internal/postgres/mappings_test.go
@@ -26,4 +26,13 @@ func TestColumnTypeMappings_Array(t *testing.T) {
 	t.Run("scalar text stays string", func(t *testing.T) {
 		require.Equal(t, "string", columnTypeMappings["text"])
 	})
+
+	// Schema introspection (ListColumns) reads information_schema.data_type = "ARRAY" (lowercased
+	// to "array" by the mapper) for every array column, with no element type available — so the
+	// generic key maps to array in both the default and legacy maps.
+	t.Run("generic 'array' (information_schema.data_type) maps to array", func(t *testing.T) {
+		require.Equal(t, "array", columnTypeMappings["array"])
+		require.Equal(t, "array", legacyColumnTypeMappings["array"])
+		require.Equal(t, "array", legacyColumnTypeMappings["_text"])
+	})
 }

--- a/sqlconnect/internal/postgres/mappings_test.go
+++ b/sqlconnect/internal/postgres/mappings_test.go
@@ -36,3 +36,21 @@ func TestColumnTypeMappings_Array(t *testing.T) {
 		require.Equal(t, "array", legacyColumnTypeMappings["_text"])
 	})
 }
+
+// jsonRowMapper must serialize string arrays as a JSON array (parse the "{a,b}" literal),
+// not as the text-literal string, so the emitted audience trait is a real JSON array.
+func TestJsonRowMapper_StringArray(t *testing.T) {
+	for _, m := range []struct {
+		name string
+		fn   func(string, any) any
+	}{{"default", jsonRowMapper}, {"legacy", legacyJsonRowMapper}} {
+		t.Run(m.name, func(t *testing.T) {
+			require.Equal(t, []string{"electronics", "books"}, m.fn("_TEXT", []byte("{electronics,books}")))
+			require.Equal(t, []string{"electronics", "books"}, m.fn("_text", []byte("{electronics,books}")), "case-insensitive")
+			require.Equal(t, []string{}, m.fn("_VARCHAR", []byte("{}")), "empty array")
+			require.Equal(t, []string{"a,b", "c"}, m.fn("_TEXT", []byte(`{"a,b","c"}`)), "quoted element with comma")
+			require.Nil(t, m.fn("_TEXT", nil), "NULL array → nil → JSON null")
+			require.Equal(t, "hello", m.fn("TEXT", []byte("hello")), "scalar text unchanged")
+		})
+	}
+}

--- a/sqlconnect/internal/redshift/legacy_mappings.go
+++ b/sqlconnect/internal/redshift/legacy_mappings.go
@@ -27,10 +27,14 @@ var legacyColumnTypeMappings = map[string]string{
 	"date":                        "datetime",
 	"timestamp without time zone": "datetime",
 	"timestamp with time zone":    "datetime",
+	"super":                       "array", // SUPER (semi-structured) → array rudder-type for the audience use case
 }
 
 // legacyJsonRowMapper maps a row's scanned column to a json object's field
 func legacyJsonRowMapper(databaseTypeName string, value any) any {
+	if databaseTypeName == "" { // SUPER and other lib/pq-unnamed types → emit JSON as raw JSON
+		return superJSONValue(value)
+	}
 	switch v := value.(type) {
 	case []byte:
 		return string(v)

--- a/sqlconnect/internal/redshift/legacy_mappings.go
+++ b/sqlconnect/internal/redshift/legacy_mappings.go
@@ -32,7 +32,9 @@ var legacyColumnTypeMappings = map[string]string{
 
 // legacyJsonRowMapper maps a row's scanned column to a json object's field
 func legacyJsonRowMapper(databaseTypeName string, value any) any {
-	if databaseTypeName == "" { // SUPER and other lib/pq-unnamed types → emit JSON as raw JSON
+	// lib/pq reports "" for SUPER (OID unknown to the driver); the Redshift Data API backend reports
+	// the real name "SUPER". Both → emit JSON as raw JSON.
+	if databaseTypeName == "" || databaseTypeName == "SUPER" {
 		return superJSONValue(value)
 	}
 	switch v := value.(type) {

--- a/sqlconnect/internal/redshift/mappings.go
+++ b/sqlconnect/internal/redshift/mappings.go
@@ -1,8 +1,28 @@
 package redshift
 
 import (
+	"encoding/json"
 	"strconv"
 )
+
+// superJSONValue emits a SUPER value as raw JSON (so an array trait is a JSON array, not a
+// string). lib/pq reports an EMPTY DatabaseTypeName for SUPER (its OID is unknown to the driver),
+// so the mapper keys on the empty type name + a valid-JSON check; known scalar types report their
+// type name and are unaffected. Non-JSON values fall through to a string.
+func superJSONValue(value any) any {
+	switch v := value.(type) {
+	case []byte:
+		if json.Valid(v) {
+			return json.RawMessage(v)
+		}
+		return string(v)
+	case string:
+		if json.Valid([]byte(v)) {
+			return json.RawMessage(v)
+		}
+	}
+	return value
+}
 
 var columnTypeMappings = map[string]string{
 	"int":                         "int",
@@ -37,6 +57,10 @@ var columnTypeMappings = map[string]string{
 	"timestamp without time zone": "datetime",
 	"timestamp with time zone":    "datetime",
 	"timestamp":                   "datetime",
+	// SUPER holds semi-structured data; for the audience array<string> use case it carries a
+	// JSON array. v1 maps it to the array rudder-type (SUPER can't distinguish array vs object
+	// at the type level, so non-array SUPER columns surface as array too).
+	"super": "array",
 }
 
 // jsonRowMapper maps a row's scanned column to a json object's field
@@ -53,6 +77,9 @@ func jsonRowMapper(databaseTypeName string, value any) any {
 				return n
 			}
 		}
+	case "":
+		// SUPER (and other Redshift-specific types lib/pq can't name) — emit JSON as raw JSON.
+		return superJSONValue(value)
 	default:
 		switch v := value.(type) {
 		case []byte:

--- a/sqlconnect/internal/redshift/mappings.go
+++ b/sqlconnect/internal/redshift/mappings.go
@@ -1,27 +1,40 @@
 package redshift
 
 import (
+	"bytes"
 	"encoding/json"
 	"strconv"
 )
 
 // superJSONValue emits a SUPER value as raw JSON (so an array trait is a JSON array, not a
 // string). lib/pq reports an EMPTY DatabaseTypeName for SUPER (its OID is unknown to the driver),
-// so the mapper keys on the empty type name + a valid-JSON check; known scalar types report their
-// type name and are unaffected. Non-JSON values fall through to a string.
+// so the mapper keys on the empty type name + this check; known scalar types report their type
+// name and are unaffected. To avoid mis-emitting a plain scalar held by some other unnamed-OID type
+// (e.g. VARBYTE/GEOMETRY reporting "" and holding the valid-JSON literal `123`/`true`), only
+// container-shaped values (a JSON array or object) are emitted as raw JSON; everything else stays a
+// string. The audience use case is array<string>, which is always a JSON array.
 func superJSONValue(value any) any {
 	switch v := value.(type) {
 	case []byte:
-		if json.Valid(v) {
+		if isJSONContainer(v) {
 			return json.RawMessage(v)
 		}
 		return string(v)
 	case string:
-		if json.Valid([]byte(v)) {
+		if isJSONContainer([]byte(v)) {
 			return json.RawMessage(v)
 		}
 	}
 	return value
+}
+
+// isJSONContainer reports whether b is valid JSON whose top level is an array or object.
+func isJSONContainer(b []byte) bool {
+	t := bytes.TrimSpace(b)
+	if len(t) == 0 || (t[0] != '[' && t[0] != '{') {
+		return false
+	}
+	return json.Valid(t)
 }
 
 var columnTypeMappings = map[string]string{

--- a/sqlconnect/internal/redshift/mappings.go
+++ b/sqlconnect/internal/redshift/mappings.go
@@ -90,8 +90,11 @@ func jsonRowMapper(databaseTypeName string, value any) any {
 				return n
 			}
 		}
-	case "":
-		// SUPER (and other Redshift-specific types lib/pq can't name) — emit JSON as raw JSON.
+	case "", "SUPER":
+		// SUPER — emit JSON as raw JSON (an array trait → JSON array). lib/pq can't resolve SUPER's
+		// OID so reports an empty name (""); the Redshift Data API backend reports the real name
+		// "SUPER". Both route here; superJSONValue handles the []byte (lib/pq) and string (Data API)
+		// value forms alike.
 		return superJSONValue(value)
 	default:
 		switch v := value.(type) {

--- a/sqlconnect/internal/redshift/mappings_test.go
+++ b/sqlconnect/internal/redshift/mappings_test.go
@@ -13,8 +13,9 @@ func TestRedshift_SuperArrayMappingAndSerialization(t *testing.T) {
 		require.Equal(t, "array", legacyColumnTypeMappings["super"])
 	})
 
-	// lib/pq reports an empty DatabaseTypeName for SUPER; its JSON value must be emitted as raw
-	// JSON (an array trait → JSON array), while non-JSON values and named types stay strings.
+	// SUPER's JSON value must be emitted as raw JSON (an array trait → JSON array), while non-JSON
+	// values and named types stay strings — on both backends: lib/pq reports an empty
+	// DatabaseTypeName for SUPER, the Redshift Data API backend reports the real name "SUPER".
 	for _, m := range []struct {
 		name string
 		fn   func(string, any) any
@@ -29,6 +30,14 @@ func TestRedshift_SuperArrayMappingAndSerialization(t *testing.T) {
 			// emitted as raw JSON — only container shapes are.
 			require.Equal(t, "123", m.fn("", []byte("123")), "bare number stays a string")
 			require.Equal(t, "true", m.fn("", []byte("true")), "bare bool stays a string")
+
+			// Redshift Data API backend reports the real type name "SUPER" and hands the value over
+			// as a string (FieldMemberStringValue); the same JSON-array emission must apply there.
+			require.Equal(t, json.RawMessage(`["electronics","books"]`), m.fn("SUPER", `["electronics","books"]`), "Data API: SUPER string → raw JSON array")
+			require.Equal(t, json.RawMessage(`[]`), m.fn("SUPER", `[]`))
+			require.Equal(t, json.RawMessage(`{"a":1}`), m.fn("SUPER", `{"a":1}`), "Data API: SUPER object → raw JSON")
+			require.Equal(t, "123", m.fn("SUPER", `123`), "Data API: bare scalar SUPER stays a string")
+			require.Equal(t, json.RawMessage(`["x"]`), m.fn("SUPER", []byte(`["x"]`)), "SUPER as []byte also handled")
 		})
 	}
 }

--- a/sqlconnect/internal/redshift/mappings_test.go
+++ b/sqlconnect/internal/redshift/mappings_test.go
@@ -1,0 +1,29 @@
+package redshift
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedshift_SuperArrayMappingAndSerialization(t *testing.T) {
+	t.Run("SUPER maps to array rudder-type (default + legacy)", func(t *testing.T) {
+		require.Equal(t, "array", columnTypeMappings["super"])
+		require.Equal(t, "array", legacyColumnTypeMappings["super"])
+	})
+
+	// lib/pq reports an empty DatabaseTypeName for SUPER; its JSON value must be emitted as raw
+	// JSON (an array trait → JSON array), while non-JSON values and named types stay strings.
+	for _, m := range []struct {
+		name string
+		fn   func(string, any) any
+	}{{"default", jsonRowMapper}, {"legacy", legacyJsonRowMapper}} {
+		t.Run(m.name, func(t *testing.T) {
+			require.Equal(t, json.RawMessage(`["electronics","books"]`), m.fn("", []byte(`["electronics","books"]`)))
+			require.Equal(t, json.RawMessage(`[]`), m.fn("", []byte(`[]`)))
+			require.Equal(t, "not json {", m.fn("", []byte("not json {")), "non-JSON SUPER value → string")
+			require.Equal(t, "hello", m.fn("VARCHAR", []byte("hello")), "named scalar type unchanged")
+		})
+	}
+}

--- a/sqlconnect/internal/redshift/mappings_test.go
+++ b/sqlconnect/internal/redshift/mappings_test.go
@@ -22,8 +22,13 @@ func TestRedshift_SuperArrayMappingAndSerialization(t *testing.T) {
 		t.Run(m.name, func(t *testing.T) {
 			require.Equal(t, json.RawMessage(`["electronics","books"]`), m.fn("", []byte(`["electronics","books"]`)))
 			require.Equal(t, json.RawMessage(`[]`), m.fn("", []byte(`[]`)))
+			require.Equal(t, json.RawMessage(`{"a":1}`), m.fn("", []byte(`{"a":1}`)), "JSON object → raw JSON")
 			require.Equal(t, "not json {", m.fn("", []byte("not json {")), "non-JSON SUPER value → string")
 			require.Equal(t, "hello", m.fn("VARCHAR", []byte("hello")), "named scalar type unchanged")
+			// A scalar value (even though valid JSON) from another unnamed-OID type must NOT be
+			// emitted as raw JSON — only container shapes are.
+			require.Equal(t, "123", m.fn("", []byte("123")), "bare number stays a string")
+			require.Equal(t, "true", m.fn("", []byte("true")), "bare bool stays a string")
 		})
 	}
 }

--- a/sqlconnect/internal/snowflake/mappings_test.go
+++ b/sqlconnect/internal/snowflake/mappings_test.go
@@ -6,6 +6,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// mockColumnType implements base.ColumnType for testing the column type mapper.
+type mockColumnType struct {
+	databaseTypeName string
+}
+
+func (m mockColumnType) DatabaseTypeName() string { return m.databaseTypeName }
+func (m mockColumnType) DecimalSize() (precision, scale int64, ok bool) {
+	return 0, 0, false
+}
+
+func TestColumnTypeMapper(t *testing.T) {
+	t.Run("ARRAY maps to array rudder-type", func(t *testing.T) {
+		result := columnTypeMapper(mockColumnType{"ARRAY"})
+		require.Equal(t, "array", result, "Snowflake ARRAY column must map to rudder-type 'array'")
+	})
+
+	t.Run("VARIANT maps to json rudder-type", func(t *testing.T) {
+		result := columnTypeMapper(mockColumnType{"VARIANT"})
+		require.Equal(t, "json", result, "Snowflake VARIANT column must map to rudder-type 'json'")
+	})
+
+	t.Run("OBJECT maps to json rudder-type", func(t *testing.T) {
+		result := columnTypeMapper(mockColumnType{"OBJECT"})
+		require.Equal(t, "json", result, "Snowflake OBJECT column must map to rudder-type 'json'")
+	})
+}
+
 func TestUndefinedInArray(t *testing.T) {
 	r, err := undefinedInArray.Replace("[\n  1,\n  2,\n  3,\n  undefined\n]", "${1}null", 0, -1)
 	require.NoError(t, err)


### PR DESCRIPTION
Part of **array<string> data-type support** for data-graph Audiences — tracking **[PRO-5781](https://linear.app/rudderstack/issue/PRO-5781)**.

## What this PR does (sqlconnect-go)
Maps `array<string>` warehouse columns to the `array` rudder-type and serializes their values as JSON arrays, on **both** the default and legacy/standard type-mapping paths, for all 5 dialects:
- **Snowflake** `ARRAY` (already mapped; confirming test).
- **Postgres** `_text`-family OIDs + generic `array`; values parsed via `pq.StringArray`.
- **Databricks** / **BigQuery** `ARRAY<STRING>` (string-element regex, before the `<…>` strip); BigQuery driver now carries the element type on the live result-set path (`columns.go`).
- **Redshift** `SUPER`; values emitted as raw JSON only for container shapes (array/object) to avoid mis-emitting scalar values.

## Release order — **step 1 of 5** (foundation)
Merge first, then **cut a tagged release**. rudder-sources (step 2) bumps to that release. See PRO-5781.

## Tests
Per-dialect mapping + serialization unit tests in each `internal/<dialect>` package; covered by the array verification harness (offline + per-dialect live) — see PRO-5781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_019a49wHRAapEKpYupJ4pv5R