### PR TITLE
test(databricks): expect null for all-null STRUCT in column-mapping testdata

### DIFF
--- a/sqlconnect/internal/databricks/testdata/column-mapping-test-rows.json
+++ b/sqlconnect/internal/databricks/testdata/column-mapping-test-rows.json
@@ -81,9 +81,6 @@
         "_timestampntz": null,
         "_array": null,
         "_map": null,
-        "_struct": {
-            "col1": null,
-            "col2": null
-        }
+        "_struct": null
     }
 ]

--- a/sqlconnect/internal/databricks/testdata/legacy-column-mapping-test-rows.json
+++ b/sqlconnect/internal/databricks/testdata/legacy-column-mapping-test-rows.json
@@ -81,6 +81,6 @@
         "_timestampntz": null,
         "_array": null,
         "_map": null,
-        "_struct": "{\"col1\":null,\"col2\":null}"
+        "_struct": null
     }
 ]


### PR DESCRIPTION
## What

Update the expected rows in the Databricks `column-mapping` integration testdata so a fully-`NULL` `STRUCT` column is expected as `null` (matching `NULL` `ARRAY` and `NULL` `MAP`, which were already expected as `null`).

```diff
# column-mapping-test-rows.json (row _order=3)
-  "_struct": { "col1": null, "col2": null }
+  "_struct": null

# legacy-column-mapping-test-rows.json (row _order=3)
-  "_struct": "{\"col1\":null,\"col2\":null}"
+  "_struct": null
```

Testdata only — no library/code changes.

## Why

The `column-mapping` row whose `_order=3` inserts SQL `NULL` for every column. `_array` and `_map` were already expected as `null`, but `_struct` was expected as an expanded `{col1:null,col2:null}`. The Databricks SQL warehouse now returns a fully-`NULL` `STRUCT` as `null`, so `jsonRowMapper` (correctly, and consistently with array/map) yields `null`. The expectation was stale.

Verified locally against the test warehouse — the `with catalog` variant now passes:
```
ok  github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/databricks  110s
```

## Why this never surfaced on CI before

The `_struct` assertion is only reached **after** a successful connection. The Databricks test credentials had expired, so the last full run on `main` failed earlier at `Ping` with `403 Forbidden` (`db_integration_test_scenario.go:60`) and never executed the `column_mapping` assertions. Every `main` run since has been a scheduled lightweight job (`stale` / CodeQL / cleanup), not the integration suite — so there has been no green databricks integration run on `main` to catch this. Once valid credentials were restored, the suite ran far enough to reach the assertion and exposed the stale expectation. Confirmed identical failure on `main` with working creds, so this is independent of any feature branch.
