### PR TITLE
feat(json): narrow json typing to native semi-structured types

### DIFF
--- a/sqlconnect/internal/bigquery/mappings.go
+++ b/sqlconnect/internal/bigquery/mappings.go
@@ -46,7 +46,7 @@ var columnTypeMappings = map[string]string{
 	"DATETIME":  "datetime",
 	"TIMESTAMP": "datetime",
 
-	"JSON":   "json",
+	"JSON": "json",
 	// Non-string arrays fall through here after stringElementArray (ARRAY<STRING|BYTES> → array).
 	// Must not map to json — json-path navigation breaks on container columns.
 	"ARRAY":  "unsupported",

--- a/sqlconnect/internal/bigquery/mappings.go
+++ b/sqlconnect/internal/bigquery/mappings.go
@@ -47,16 +47,18 @@ var columnTypeMappings = map[string]string{
 	"TIMESTAMP": "datetime",
 
 	"JSON":   "json",
-	"ARRAY":  "json",
-	"STRUCT": "json", // STRUCT and RECORD are represented as an array of json objects
-	"RECORD": "json",
+	// Non-string arrays fall through here after stringElementArray (ARRAY<STRING|BYTES> → array).
+	// Must not map to json — json-path navigation breaks on container columns.
+	"ARRAY":  "unsupported",
+	"STRUCT": "unsupported",
+	"RECORD": "unsupported",
 }
 
 var re = regexp.MustCompile(`(\(.+\)|<.+>)`) // remove type parameters [<>] and size constraints [()]
 
 // stringElementArray matches ARRAY<STRING|BYTES ...> — string-element arrays map to the array
 // rudder-type in v1 (checked before the type-parameter strip). Other element types (e.g.
-// ARRAY<INT64>) fall through to the generic ARRAY → json mapping (surfaced as unsupported).
+// ARRAY<INT64>) fall through to the generic ARRAY → unsupported mapping.
 var stringElementArray = regexp.MustCompile(`^ARRAY<\s*(STRING|BYTES)`)
 
 func columnTypeMapper(columnType base.ColumnType) string {

--- a/sqlconnect/internal/bigquery/mappings_array_test.go
+++ b/sqlconnect/internal/bigquery/mappings_array_test.go
@@ -15,7 +15,8 @@ func TestColumnTypeMapper_Array(t *testing.T) {
 	for _, raw := range []string{"ARRAY<STRING>", "array<string>", "ARRAY<BYTES>"} {
 		require.Equal(t, "array", columnTypeMapper(mockCT{raw}), raw)
 	}
-	require.Equal(t, "json", columnTypeMapper(mockCT{"ARRAY<INT64>"}), "non-string array stays json")
+	require.Equal(t, "unsupported", columnTypeMapper(mockCT{"ARRAY<INT64>"}), "non-string array is unsupported")
 	require.Equal(t, "string", columnTypeMapper(mockCT{"STRING"}))
-	require.Equal(t, "json", columnTypeMapper(mockCT{"STRUCT<a INT64>"}))
+	require.Equal(t, "unsupported", columnTypeMapper(mockCT{"STRUCT<a INT64>"}))
+	require.Equal(t, "unsupported", columnTypeMapper(mockCT{"RECORD"}))
 }

--- a/sqlconnect/internal/bigquery/testdata/column-mapping-test-columns.json
+++ b/sqlconnect/internal/bigquery/testdata/column-mapping-test-columns.json
@@ -23,7 +23,7 @@
     "_numeric": "float",
     "_decimal": "float",
     "_string": "string",
-    "_struct": "json",
+    "_struct": "unsupported",
     "_time": "datetime",
     "_timestamp": "datetime"
 }

--- a/sqlconnect/internal/databricks/legacy_mappings.go
+++ b/sqlconnect/internal/databricks/legacy_mappings.go
@@ -27,13 +27,14 @@ func legacyColumnTypeMapper(columnType base.ColumnType) string {
 		"VOID":          "string",
 		"TIMESTAMP":     "datetime",
 		"TIMESTAMP_NTZ": "datetime",
-		"ARRAY":         "json",
-		"MAP":           "json",
-		"STRUCT":        "json",
+		"ARRAY":         "unsupported",
+		"MAP":           "unsupported",
+		"VARIANT":       "json",
+		"STRUCT":        "unsupported",
 	}
 	raw := strings.ToUpper(columnType.DatabaseTypeName())
 	// String-element arrays map to the array rudder-type (checked before the type-parameter
-	// strip); other element types fall through to the generic ARRAY → json mapping. Mirrors
+	// strip); other element types fall through to the generic ARRAY → unsupported mapping. Mirrors
 	// the non-legacy columnTypeMapper so the schema path (useStandardTypeMappings) agrees.
 	if stringElementArray.MatchString(raw) {
 		return "array"

--- a/sqlconnect/internal/databricks/mappings.go
+++ b/sqlconnect/internal/databricks/mappings.go
@@ -42,16 +42,18 @@ var columnTypeMappings = map[string]string{
 	"TIMESTAMP":     "datetime",
 	"TIMESTAMP_NTZ": "datetime",
 
-	"ARRAY":  "json",
-	"MAP":    "json",
-	"STRUCT": "json",
+	"VARIANT": "json",
+	// Non-string arrays fall through here after stringElementArray (ARRAY<STRING|…> → array).
+	"ARRAY":   "unsupported",
+	"MAP":     "unsupported",
+	"STRUCT":  "unsupported",
 }
 
 var re = regexp.MustCompile(`(\(.+\)|<.+>)`) // remove type parameters [<>] and size constraints [()]
 
 // stringElementArray matches ARRAY<STRING|VARCHAR|CHAR ...> — string-element arrays
 // that map to the array rudder-type in v1. Other element types (e.g. ARRAY<BIGINT>)
-// fall through to the generic ARRAY → json mapping (surfaced as unsupported).
+// fall through to the generic ARRAY → unsupported mapping.
 var stringElementArray = regexp.MustCompile(`^ARRAY<\s*(STRING|VARCHAR|CHAR)`)
 
 func columnTypeMapper(columnType base.ColumnType) string {

--- a/sqlconnect/internal/databricks/mappings.go
+++ b/sqlconnect/internal/databricks/mappings.go
@@ -44,9 +44,9 @@ var columnTypeMappings = map[string]string{
 
 	"VARIANT": "json",
 	// Non-string arrays fall through here after stringElementArray (ARRAY<STRING|…> → array).
-	"ARRAY":   "unsupported",
-	"MAP":     "unsupported",
-	"STRUCT":  "unsupported",
+	"ARRAY":  "unsupported",
+	"MAP":    "unsupported",
+	"STRUCT": "unsupported",
 }
 
 var re = regexp.MustCompile(`(\(.+\)|<.+>)`) // remove type parameters [<>] and size constraints [()]

--- a/sqlconnect/internal/databricks/mappings_test.go
+++ b/sqlconnect/internal/databricks/mappings_test.go
@@ -23,16 +23,18 @@ func TestColumnTypeMapper_Array(t *testing.T) {
 		}
 	})
 
-	t.Run("non-string-element arrays stay json (unsupported in v1)", func(t *testing.T) {
+	t.Run("non-string-element arrays are unsupported in v1", func(t *testing.T) {
 		for _, raw := range []string{"ARRAY<BIGINT>", "ARRAY<INT>", "ARRAY<DOUBLE>", "ARRAY<STRUCT<a:INT>>"} {
-			require.Equal(t, "json", columnTypeMapper(mockColumnType{raw}), raw)
+			require.Equal(t, "unsupported", columnTypeMapper(mockColumnType{raw}), raw)
 		}
 	})
 
-	t.Run("scalar types unaffected", func(t *testing.T) {
+	t.Run("scalar and semi-structured types", func(t *testing.T) {
 		require.Equal(t, "string", columnTypeMapper(mockColumnType{"STRING"}))
 		require.Equal(t, "int", columnTypeMapper(mockColumnType{"BIGINT"}))
-		require.Equal(t, "json", columnTypeMapper(mockColumnType{"MAP<STRING,INT>"}))
+		require.Equal(t, "unsupported", columnTypeMapper(mockColumnType{"MAP<STRING,INT>"}))
+		require.Equal(t, "json", columnTypeMapper(mockColumnType{"VARIANT"}))
+		require.Equal(t, "unsupported", columnTypeMapper(mockColumnType{"STRUCT<a:INT>"}))
 	})
 }
 
@@ -43,7 +45,7 @@ func TestLegacyColumnTypeMapper_Array(t *testing.T) {
 		require.Equal(t, "array", legacyColumnTypeMapper(mockColumnType{raw}), raw)
 	}
 	for _, raw := range []string{"ARRAY<BIGINT>", "ARRAY<INT>"} {
-		require.Equal(t, "json", legacyColumnTypeMapper(mockColumnType{raw}), raw)
+		require.Equal(t, "unsupported", legacyColumnTypeMapper(mockColumnType{raw}), raw)
 	}
 	require.Equal(t, "string", legacyColumnTypeMapper(mockColumnType{"STRING"}))
 }

--- a/sqlconnect/internal/databricks/testdata/column-mapping-test-columns.json
+++ b/sqlconnect/internal/databricks/testdata/column-mapping-test-columns.json
@@ -22,7 +22,7 @@
     "_date": "datetime",
     "_timestamp": "datetime",
     "_timestampntz": "datetime",
-    "_array": "json",
-    "_map": "json",
-    "_struct": "json"
+    "_array": "unsupported",
+    "_map": "unsupported",
+    "_struct": "unsupported"
 }

--- a/sqlconnect/internal/databricks/testdata/legacy-column-mapping-test-columns-sql.json
+++ b/sqlconnect/internal/databricks/testdata/legacy-column-mapping-test-columns-sql.json
@@ -22,7 +22,7 @@
     "_date": "datetime",
     "_timestamp": "datetime",
     "_timestampntz": "datetime",
-    "_array": "json",
-    "_map": "json",
-    "_struct": "json"
+    "_array": "unsupported",
+    "_map": "unsupported",
+    "_struct": "unsupported"
 }

--- a/sqlconnect/internal/databricks/testdata/legacy-column-mapping-test-columns-table.json
+++ b/sqlconnect/internal/databricks/testdata/legacy-column-mapping-test-columns-table.json
@@ -22,7 +22,7 @@
     "_date": "datetime",
     "_timestamp": "datetime",
     "_timestampntz": "datetime",
-    "_array": "json",
-    "_map": "json",
-    "_struct": "json"
+    "_array": "unsupported",
+    "_map": "unsupported",
+    "_struct": "unsupported"
 }

--- a/sqlconnect/internal/integration_test/db_integration_test_scenario.go
+++ b/sqlconnect/internal/integration_test/db_integration_test_scenario.go
@@ -1067,6 +1067,8 @@ func TestDatabaseScenarios(t *testing.T, warehouse string, configJSON json.RawMe
 
 				case "json":
 					// this can be anything
+				case "unsupported":
+					// container/composite columns excluded from json-path typing; values still scan
 				default:
 					t.Errorf("unexpected column type %s for column  %q: %v", col.Type, col.Name, actualRow[col.Name])
 				}


### PR DESCRIPTION
## Summary
- BigQuery: `STRUCT`/`RECORD` and non-string `ARRAY` → `unsupported` (native `JSON` stays `json`)
- Databricks: `VARIANT` → `json`; `MAP`, `STRUCT`, non-string `ARRAY` → `unsupported`
- Keeps Snowflake `VARIANT`/`OBJECT` and Postgres `json`/`jsonb` as `json`

Spec: [json-column-filters LLD](https://github.com/rudderlabs/rudder-specs/blob/feat/json-column-filters-spec/audiences-next-initiative/audience-builder/llds/json-column-filters/spec.md) · merge **before** rudder-sources

## Test matrix (spec Part 2 — sqlconnect typing)

| # | Dialect | Raw type | Expected rudder `type` | Unit test |
|---|---------|----------|------------------------|-----------|
| 13 | Snowflake | `VARIANT` / `OBJECT` | `json` | existing mappings |
| 14 | BigQuery | `JSON` | `json` | ✅ |
| 15 | BigQuery | `STRUCT<...>` / `RECORD` | `unsupported` | ✅ `mappings_array_test` |
| 16 | Postgres | `json` / `jsonb` | `json` | existing mappings |
| 17 | Databricks | `VARIANT` | `json` | ✅ `mappings_test` |
| 18 | Databricks | `STRUCT<...>` | `unsupported` | ✅ `mappings_test` |

**Also:** non-string `ARRAY` on BQ/DBX → `unsupported` (never `json`).

## Test plan
- [x] `go test ./sqlconnect/internal/bigquery/... ./sqlconnect/internal/databricks/...`
- [ ] CI green
- [ ] Release + version bump for rudder-sources consumer


Made with [Cursor](https://cursor.com)