### PR TITLE
fix(mysql): build the dsn from typed fields instead of string formatting

### DIFF
--- a/sqlconnect/internal/mysql/config.go
+++ b/sqlconnect/internal/mysql/config.go
@@ -3,6 +3,10 @@ package mysql
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"strconv"
+
+	mysqldriver "github.com/go-sql-driver/mysql"
 
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/sshtunnel"
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/util"
@@ -23,12 +27,28 @@ type Config struct {
 	UseLegacyMappings  bool `json:"useLegacyMappings"`
 }
 
+// ConnectionString builds the go-sql-driver DSN from typed fields.
+//
+// Do not rewrite this to format the DSN by hand. Every value here comes from
+// caller-supplied connection config, and the driver reads part of the DSN as
+// connection parameters, so an unescaped field can change the settings the
+// driver ends up with. FormatDSN escapes each field for us.
 func (c Config) ConnectionString() (string, error) {
 	tls, err := c.TLS()
 	if err != nil {
-		return "", fmt.Errorf("error while creating connecton string, %w", err)
+		return "", fmt.Errorf("creating connection string: %w", err)
 	}
-	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=%s", c.User, c.Password, c.Host, c.Port, c.DBName, tls), nil
+	cfg := mysqldriver.NewConfig()
+	cfg.User = c.User
+	cfg.Passwd = c.Password
+	cfg.Net = "tcp"
+	cfg.Addr = net.JoinHostPort(c.Host, strconv.Itoa(c.Port))
+	cfg.DBName = c.DBName
+	cfg.TLSConfig = tls
+	// Pinned explicitly: reading local files on behalf of the server is never
+	// wanted here, and the connection config is caller-supplied.
+	cfg.AllowAllFiles = false
+	return cfg.FormatDSN(), nil
 }
 
 func (c Config) TLS() (string, error) {

--- a/sqlconnect/internal/mysql/config_test.go
+++ b/sqlconnect/internal/mysql/config_test.go
@@ -1,8 +1,10 @@
 package mysql_test
 
 import (
+	"fmt"
 	"testing"
 
+	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 
 	"github.com/rudderlabs/sqlconnect-go/sqlconnect/internal/mysql"
@@ -46,6 +48,105 @@ func TestConfig(t *testing.T) {
 			c := mysql.Config{SSLMode: "other"}
 			_, err := c.TLS()
 			require.Error(t, err, "should not allow other tls")
+		})
+	})
+
+	t.Run("connection string", func(t *testing.T) {
+		baseConfig := func(dbname string) mysql.Config {
+			return mysql.Config{
+				Host: "db.example.com", Port: 3306,
+				User: "rudder_svc", Password: "s3cr3t",
+				DBName: dbname, SSLMode: "false",
+			}
+		}
+
+		// dbname is caller-supplied and part of the DSN the driver parses, so
+		// values containing DSN syntax must not be able to change the settings
+		// the driver ends up with. AllowAllFiles in particular must stay off.
+		t.Run("dbname cannot alter driver parameters", func(t *testing.T) {
+			for _, dbname := range []string{
+				`prod?allowAllFiles=true&`, // the reported payload
+				`prod?allowAllFiles=1`,
+				`prod?allowAllFiles=true&tls=skip-verify`,
+				`prod&allowAllFiles=true`,
+				`prod?allowAllFiles=true#frag`,
+				`prod%3FallowAllFiles=true`,
+				`prod?loc=UTC&parseTime=true`,
+			} {
+				t.Run(dbname, func(t *testing.T) {
+					dsn, err := baseConfig(dbname).ConnectionString()
+					require.NoError(t, err, "it should build a connection string")
+
+					parsed, err := mysqldriver.ParseDSN(dsn)
+					require.NoError(t, err, "the driver should parse the generated dsn")
+
+					require.False(t, parsed.AllowAllFiles,
+						"allowAllFiles must never be enabled via dbname, dsn: %s", dsn)
+					require.Equal(t, dbname, parsed.DBName,
+						"dbname must round-trip literally, dsn: %s", dsn)
+					require.NotContains(t, parsed.Params, "allowAllFiles",
+						"allowAllFiles must not leak into params, dsn: %s", dsn)
+				})
+			}
+		})
+
+		// The DSN used to be built with this format string. Parsing both and
+		// comparing proves the move to FormatDSN did not change how the driver
+		// sees a benign connection — mysqldriver.NewConfig() sets defaults that
+		// the old DSN left implicit, and this is what catches any drift.
+		t.Run("matches the previously hand-built dsn for a benign config", func(t *testing.T) {
+			c := baseConfig("analytics")
+
+			legacy := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?tls=%s",
+				c.User, c.Password, c.Host, c.Port, c.DBName, "false")
+			legacyParsed, err := mysqldriver.ParseDSN(legacy)
+			require.NoError(t, err, "the legacy dsn should parse")
+
+			dsn, err := c.ConnectionString()
+			require.NoError(t, err, "it should build a connection string")
+			parsed, err := mysqldriver.ParseDSN(dsn)
+			require.NoError(t, err, "the generated dsn should parse")
+
+			require.Equal(t, legacyParsed, parsed,
+				"the driver must see an identical config, legacy: %s, new: %s", legacy, dsn)
+		})
+
+		t.Run("tls mode reaches the driver", func(t *testing.T) {
+			for sslMode, want := range map[string]string{
+				"":            "false",
+				"false":       "false",
+				"skip-verify": "skip-verify",
+			} {
+				c := baseConfig("analytics")
+				c.SSLMode = sslMode
+				dsn, err := c.ConnectionString()
+				require.NoError(t, err, "it should build a connection string for %q", sslMode)
+				parsed, err := mysqldriver.ParseDSN(dsn)
+				require.NoError(t, err, "the generated dsn should parse for %q", sslMode)
+				require.Equal(t, want, parsed.TLSConfig, "sslmode %q", sslMode)
+			}
+		})
+
+		t.Run("ipv6 host", func(t *testing.T) {
+			c := baseConfig("analytics")
+			c.Host = "2001:db8::1"
+			dsn, err := c.ConnectionString()
+			require.NoError(t, err, "it should build a connection string")
+			parsed, err := mysqldriver.ParseDSN(dsn)
+			require.NoError(t, err, "the driver should parse an ipv6 address, dsn: %s", dsn)
+			require.Equal(t, "[2001:db8::1]:3306", parsed.Addr, "it should bracket the address")
+		})
+
+		t.Run("credentials with dsn metacharacters", func(t *testing.T) {
+			c := baseConfig("analytics")
+			c.User = "user@host"
+			c.Password = "p@ss:w/rd?x"
+			dsn, err := c.ConnectionString()
+			require.NoError(t, err, "it should build a connection string")
+			parsed, err := mysqldriver.ParseDSN(dsn)
+			require.NoError(t, err, "the driver should parse the generated dsn, dsn: %s", dsn)
+			require.Equal(t, "user@host", parsed.User, "user should round-trip")
+			require.Equal(t, "p@ss:w/rd?x", parsed.Passwd, "password should round-trip")
 		})
 	})
 }


### PR DESCRIPTION
Builds the MySQL DSN with `mysql.Config` + `FormatDSN()` instead of a format string.

Everything in `Config` is caller-supplied, and the driver reads part of the DSN as connection parameters — so interpolating those values by hand meant an unescaped field could change the settings the driver ended up with. `FormatDSN` escapes each field, and `DBName` round-trips exactly (`url.PathEscape` out, `url.PathUnescape` back).

This matches what the other connectors already do: Postgres uses `url.URL` + `Values.Encode`, Snowflake uses `gosnowflake.DSN`. MySQL was the last hand-built DSN.

Also fixes IPv6 hosts — `%s:%d` produced a malformed address, `net.JoinHostPort` doesn't.

**Worth a close look:** the differential test. `mysql.NewConfig()` sets defaults the old DSN left implicit, so the test parses both the old and new DSNs for a benign config and requires the driver to see an identical `mysql.Config`. That's the evidence nothing moved for existing connections. The `sslmode` test covers the other risk, since all TLS behaviour flows through that one field.

Internal tracking: PRO-5872.
